### PR TITLE
feat: add dev command to regenerate TTSL opcodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ To set up a development version of this engine:
     ```bash
     uv run pytest
     ```
+8. Regenerate TTSL opcode/ABI files after opcode definition changes:
+    ```bash
+    uv run tt3de-gen-opcodes
+    ```
 
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,9 @@ readme = "README.md"
 requires-python = ">=3.11"
 version = "0.1.2"
 
+[project.scripts]
+tt3de-gen-opcodes = "tt3de.ttsl.ttisa.low_level_def:main"
+
 [tool.maturin]
 # "extension-module" tells pyo3 we want to build an extension module (skips linking against libpython.so)
 features = ["pyo3/extension-module"]

--- a/python/tt3de/ttsl/ttisa/low_level_def.py
+++ b/python/tt3de/ttsl/ttisa/low_level_def.py
@@ -390,16 +390,16 @@ def generate_read_axis_forms():
                     "bank": "f32_",
                 }
             )
-            match_code = f"""
-                {form["name"]} => {{
-                    {Rustgen.unsafe_block(
-                        f"""
+            rust_body = f"""
                     {Rustgen.let_base_register_be(ir_type)}
                     {Rustgen.let_operand_register_be("a", ir_type)}
                     {Rustgen.let_base_register_be(IRType.F32)}
                     *base_f32_.add(dst as usize) = a_val.{axis_name.lower()};
                     """
-                    )}
+            rust_body = Rustgen.unsafe_block(rust_body)
+            match_code = f"""
+                {form["name"]} => {{
+                    {rust_body}
                 None
                 }}
                 """
@@ -620,8 +620,7 @@ def generate_all_forms() -> List[Form]:
     return all_generated_forms
 
 
-RERE = 23
-if __name__ == "__main__":
+def main() -> None:
     all_generated_forms = generate_all_forms()
     # now generate the rust file
 
@@ -682,3 +681,7 @@ if __name__ == "__main__":
     ]
     with open("python/tt3de/ttsl/ttisa/ttisa_opcodes.py", "w") as f:
         f.write("\n".join(op_code_definitions_statement_py))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/ttsl/opcodes.rs
+++ b/src/ttsl/opcodes.rs
@@ -723,8 +723,8 @@ let a_val = *base_v4.add(a as usize);
 
 
                 CMP_GT_F32 => {
-                    unsafe { let base_f32_ = regs.f32_.as_mut_ptr();
-let base_bool_ = regs.bool_.as_mut_ptr();
+                    unsafe { let base_bool_ = regs.bool_.as_mut_ptr();
+let base_f32_ = regs.f32_.as_mut_ptr();
 let a_val = *base_f32_.add(a as usize);
 let b_val = *base_f32_.add(b as usize);
 *base_bool_.add(dst as usize) = a_val > b_val;
@@ -734,8 +734,8 @@ let b_val = *base_f32_.add(b as usize);
 
 
                 CMP_GTE_F32 => {
-                    unsafe { let base_f32_ = regs.f32_.as_mut_ptr();
-let base_bool_ = regs.bool_.as_mut_ptr();
+                    unsafe { let base_bool_ = regs.bool_.as_mut_ptr();
+let base_f32_ = regs.f32_.as_mut_ptr();
 let a_val = *base_f32_.add(a as usize);
 let b_val = *base_f32_.add(b as usize);
 *base_bool_.add(dst as usize) = a_val >= b_val;
@@ -745,8 +745,8 @@ let b_val = *base_f32_.add(b as usize);
 
 
                 CMP_GT_I32 => {
-                    unsafe { let base_i32_ = regs.i32_.as_mut_ptr();
-let base_bool_ = regs.bool_.as_mut_ptr();
+                    unsafe { let base_bool_ = regs.bool_.as_mut_ptr();
+let base_i32_ = regs.i32_.as_mut_ptr();
 let a_val = *base_i32_.add(a as usize);
 let b_val = *base_i32_.add(b as usize);
 *base_bool_.add(dst as usize) = a_val > b_val;
@@ -756,8 +756,8 @@ let b_val = *base_i32_.add(b as usize);
 
 
                 CMP_GTE_I32 => {
-                    unsafe { let base_i32_ = regs.i32_.as_mut_ptr();
-let base_bool_ = regs.bool_.as_mut_ptr();
+                    unsafe { let base_bool_ = regs.bool_.as_mut_ptr();
+let base_i32_ = regs.i32_.as_mut_ptr();
 let a_val = *base_i32_.add(a as usize);
 let b_val = *base_i32_.add(b as usize);
 *base_bool_.add(dst as usize) = a_val >= b_val;


### PR DESCRIPTION
Expose the opcode generator as a runnable project script and document the command so ABI/opcode artifacts can be regenerated consistently during development.