### PR TITLE
fix: correct triangle clipping, texture sampling, and doc-tests

### DIFF
--- a/src/drawbuffer/segment_cache.rs
+++ b/src/drawbuffer/segment_cache.rs
@@ -46,7 +46,7 @@ impl SegmentCache {
     /// # Examples
     ///
     /// ```
-    /// use rtt3de::drawbuffer::segment_cache::SegmentCache;
+    /// use tt3de::drawbuffer::segment_cache::SegmentCache;
     /// let value = 200;
     /// let bit_size = 4;
     /// assert_eq!(SegmentCache::reduce_value(value, bit_size),12 );

--- a/src/primitiv_building/triangle_clipping.rs
+++ b/src/primitiv_building/triangle_clipping.rs
@@ -203,13 +203,16 @@ pub fn clip_triangle_to_plane<const INNER_SIZE: usize>(
 /// # Example
 ///
 /// ```
+/// use nalgebra_glm::{Vec4, Vec2};
+/// use tt3de::primitiv_building::triangle_clipping::{clip_triangle_to_clip_space, SmallTriangleBuffer};
+///
 /// let pa = Vec4::new(1.0, 1.0, 1.0, 1.0);
 /// let pb = Vec4::new(-1.0, -1.0, 1.0, 1.0);
 /// let pc = Vec4::new(0.0, 1.0, 1.0, 1.0);
 /// let uva = Vec2::new(0.0, 0.0);
 /// let uvb = Vec2::new(1.0, 0.0);
 /// let uvc = Vec2::new(0.5, 1.0);
-/// let mut output_buffer = TriangleBuffer::new();
+/// let mut output_buffer: SmallTriangleBuffer<12> = SmallTriangleBuffer::new();
 /// clip_triangle_to_clip_space(&pa, &pb, &pc, (&uva, &uvb, &uvc), &mut output_buffer);
 /// ```
 pub fn clip_triangle_to_clip_space(
@@ -221,12 +224,12 @@ pub fn clip_triangle_to_clip_space(
 ) {
     // defining the plane of the clipping
     let planes = [
-        (Vec4::new(0.0, 0.0, -1.0, 1.0), 1), // far
-        (Vec4::new(-1.0, 0.0, 0.0, 1.0), 1), //
-        (Vec4::new(1.0, 0.0, 0.0, 1.0), 1),  //
-        (Vec4::new(0.0, -1.0, 0.0, 1.0), 1), //
-        (Vec4::new(0.0, 1.0, 0.0, 1.0), 1),  //
-        (Vec4::new(0.0, 0.0, 1.0, 0.0), 0), // near// will use the full clipping method, generating more triangle potentially
+        (Vec4::new(0.0, 0.0, -1.0, 1.0), 0), // far:    z ≤ w
+        (Vec4::new(-1.0, 0.0, 0.0, 1.0), 0), // right:  x ≤ w
+        (Vec4::new(1.0, 0.0, 0.0, 1.0), 0),  // left:   x ≥ -w
+        (Vec4::new(0.0, -1.0, 0.0, 1.0), 0), // top:    y ≤ w
+        (Vec4::new(0.0, 1.0, 0.0, 1.0), 0),  // bottom: y ≥ -w
+        (Vec4::new(0.0, 0.0, 1.0, 0.0), 0),  // near:   z ≥ 0
     ];
 
     output_buffer.clear();
@@ -310,6 +313,7 @@ mod tests_clip_triangle_to_space {
         };
     }
     const UVACCURACY_TEST: f32 = 0.001;
+    const VERTEX_EPS: f32 = 0.001;
     use super::*;
 
     #[test]
@@ -361,42 +365,39 @@ mod tests_clip_triangle_to_space {
 
         // Expect the triangle to be clipped into 4 triangles
         let clipped_triangle = output_buffer.content[0];
-        assert_eq!(clipped_triangle[0], pa);
-        assert_eq!(clipped_triangle[1], Vec4::new(1.0, 0.0, 0.0, 1.0));
-        assert_eq!(clipped_triangle[2], Vec4::new(0.0, 1.0, 0.0, 1.0));
-        // testing the uv calculation of  sub triangle
+        assert_eq_vec3!(clipped_triangle[0], pa, VERTEX_EPS);
+        assert_eq_vec3!(clipped_triangle[1], Vec4::new(1.0, 0.0, 0.0, 1.0), VERTEX_EPS);
+        assert_eq_vec3!(clipped_triangle[2], Vec4::new(0.0, 1.0, 0.0, 1.0), VERTEX_EPS);
         let clipped_uvs = output_buffer.uvs[0];
-        assert_eq_vec2!(clipped_uvs[0], *uvs.0, 0.001);
+        assert_eq_vec2!(clipped_uvs[0], *uvs.0, UVACCURACY_TEST);
         assert_eq_vec2!(clipped_uvs[1], Vec2::new(0.666_666_7, 0.0), UVACCURACY_TEST);
         assert_eq_vec2!(clipped_uvs[2], Vec2::new(0.0, 0.666_666_7), UVACCURACY_TEST);
 
         // triangle 1
         let clipped_triangle = output_buffer.content[1];
-        assert_eq!(clipped_triangle[0], Vec4::new(1.0, 0.0, 0.0, 1.0));
-        assert_eq!(clipped_triangle[1], Vec4::new(0.0, 1.0, 0.0, 1.0));
-        assert_eq!(clipped_triangle[2], Vec4::new(0.3333333, 1.0, 0.0, 1.0));
-        // testing the uv calculation of  sub triangle
+        assert_eq_vec3!(clipped_triangle[0], Vec4::new(1.0, 0.0, 0.0, 1.0), VERTEX_EPS);
+        assert_eq_vec3!(clipped_triangle[1], Vec4::new(0.0, 1.0, 0.0, 1.0), VERTEX_EPS);
+        assert_eq_vec3!(clipped_triangle[2], Vec4::new(0.3333333, 1.0, 0.0, 1.0), VERTEX_EPS);
         let clipped_uvs = output_buffer.uvs[1];
         assert_eq_vec2!(clipped_uvs[0], Vec2::new(0.666667, 0.0), UVACCURACY_TEST);
         assert_eq_vec2!(clipped_uvs[1], Vec2::new(0.0, 0.666667), UVACCURACY_TEST);
         assert_eq_vec2!(clipped_uvs[2], Vec2::new(0.2222, 0.666667), UVACCURACY_TEST);
 
-        //triangle 2
+        // triangle 2
         let clipped_triangle = output_buffer.content[2];
-        assert_eq!(clipped_triangle[0], Vec4::new(1.0, 0.0, 0.0, 1.0));
-        assert_eq!(clipped_triangle[1], Vec4::new(1.0, 0.5, 0.0, 1.0));
-        assert_eq!(clipped_triangle[2], Vec4::new(0.3333333, 1.0, 0.0, 1.0));
-        // testing the uv calculation of  sub triangle
+        assert_eq_vec3!(clipped_triangle[0], Vec4::new(1.0, 0.0, 0.0, 1.0), VERTEX_EPS);
+        assert_eq_vec3!(clipped_triangle[1], Vec4::new(1.0, 0.5, 0.0, 1.0), VERTEX_EPS);
+        assert_eq_vec3!(clipped_triangle[2], Vec4::new(0.3333333, 1.0, 0.0, 1.0), VERTEX_EPS);
         let clipped_uvs = output_buffer.uvs[2];
         assert_eq_vec2!(clipped_uvs[0], Vec2::new(0.666667, 0.0), UVACCURACY_TEST);
         assert_eq_vec2!(clipped_uvs[1], Vec2::new(0.66667, 0.33333), UVACCURACY_TEST);
         assert_eq_vec2!(clipped_uvs[2], Vec2::new(0.2222, 0.666667), UVACCURACY_TEST);
 
+        // triangle 3
         let clipped_triangle = output_buffer.content[3];
-        assert_eq!(clipped_triangle[0], Vec4::new(1.0, 0.5, 0.0, 1.0));
-        assert_eq!(clipped_triangle[1], Vec4::new(0.3333333, 1.0, 0.0, 1.0));
-        assert_eq!(clipped_triangle[2], Vec4::new(0.5, 1.0, 0.0, 1.0));
-        // testing the uv calculation of  sub triangle
+        assert_eq_vec3!(clipped_triangle[0], Vec4::new(1.0, 0.5, 0.0, 1.0), VERTEX_EPS);
+        assert_eq_vec3!(clipped_triangle[1], Vec4::new(0.3333333, 1.0, 0.0, 1.0), VERTEX_EPS);
+        assert_eq_vec3!(clipped_triangle[2], Vec4::new(0.5, 1.0, 0.0, 1.0), VERTEX_EPS);
         let clipped_uvs = output_buffer.uvs[3];
         assert_eq_vec2!(clipped_uvs[0], Vec2::new(0.66667, 0.33333), UVACCURACY_TEST);
         assert_eq_vec2!(clipped_uvs[1], Vec2::new(0.2222, 0.666667), UVACCURACY_TEST);

--- a/src/raster/raster_triangle_tomato.rs
+++ b/src/raster/raster_triangle_tomato.rs
@@ -13,12 +13,14 @@ use super::{primitivbuffer::PrimitivReferences, Vertex};
 ///
 /// The following ASCII diagram illustrates the vertex positions:
 ///
+/// ```text
 ///         pa
 ///         /\
 ///        /  \
 ///       /    \
 ///      /      \
 ///    pb--------pc
+/// ```
 ///
 /// # Parameters
 ///
@@ -71,12 +73,14 @@ pub fn draw_flat_bottom_triangle<const DEPTHCOUNT: usize>(
 ///
 /// The following ASCII diagram illustrates the vertex positions:
 ///
+/// ```text
 ///           pa-----------pb
 ///             \         /
 ///              \       /
 ///               \     /
 ///                \   /
 ///                  pc
+/// ```
 /// # Parameters
 ///
 /// - `drawing_buffer`: A mutable reference to the drawing buffer used for rendering.

--- a/src/texturebuffer/mod.rs
+++ b/src/texturebuffer/mod.rs
@@ -42,9 +42,9 @@ impl RGBA {
     pub fn mult_albedo(&self, factor: f32) -> Self {
         let f = factor.clamp(0.0, 1.0);
         RGBA {
-            r: (self.r as f32 * f) as u8,
-            g: (self.g as f32 * f) as u8,
-            b: (self.b as f32 * f) as u8,
+            r: (self.r as f32 * f).round() as u8,
+            g: (self.g as f32 * f).round() as u8,
+            b: (self.b as f32 * f).round() as u8,
             a: self.a,
         }
     }
@@ -198,12 +198,10 @@ impl<const SIZE: usize> TextureCustom<SIZE> {
             v.clamp(0.0, 1.0)
         };
 
-        // Convert u, v to texture coordinates
-        let x = (u_val * self.width as f32) as usize;
-        let y = (v_val * self.height as f32) as usize;
+        let x = ((u_val * self.width as f32) as usize).min(self.width - 1);
+        let y = ((v_val * self.height as f32) as usize).min(self.height - 1);
 
         self.texture.data[y * self.width + x]
-        //self.texture.data[x * self.height + y]
     }
 }
 


### PR DESCRIPTION
- Use full clip_triangle_to_plane on all 6 frustum planes instead of half_clip, which was passing triangles through without clipping geometry.
- Clamp TextureCustom pixel indices at boundary UV values to prevent out-of-bounds sampling.
- Round color channels in mult_albedo instead of truncating to avoid off-by-one errors.
- Fix doc-tests: correct crate name (rtt3de to tt3de), add missing imports in clip_triangle_to_clip_space example, wrap ASCII art in text blocks.
- Use epsilon-based vertex assertions in clipping tests to handle floating-point precision.