### PR TITLE
fix: resolve all Rust compilation warnings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,21 @@
+# Agent Guidelines for tt3de
+
+## Build
+
+This is a mixed Rust/Python project using [maturin](https://www.maturin.rs/).
+
+- **Compile locally**: `uv run maturin develop` (dev profile) or `uv run maturin develop --profile release`
+- **Rust check (all targets)**: `cargo check --all-targets` — use this to surface all warnings, including from tests and benchmarks.
+- **Rust tests**: `cargo test`
+- **Python tests**: `uv run pytest`
+- **Regenerate TTSL opcodes**: `uv run tt3de-gen-opcodes`
+
+## Platform Notes
+
+- On Windows/PowerShell, redirect cargo stderr with: `cmd /c "cargo check --all-targets 2> output.txt"` (PowerShell `2>&1` piping mangles cargo output).
+
+## Conventions
+
+- Keep changes scoped; avoid unrelated refactors in the same edit.
+- Run `cargo check --all-targets` after Rust edits to verify zero warnings.
+- Run `uv run pytest` after changes that touch Python bindings.

--- a/benches/all.rs
+++ b/benches/all.rs
@@ -1,5 +1,5 @@
 use crate::bench_bertex_buffer::{bench_mvp};
-use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use criterion::{criterion_group, criterion_main, Criterion};
 pub mod color_bench;
 use color_bench::{bench_blend_f32, bench_blend_i16, bench_blend_u8};
 

--- a/benches/color_bench.rs
+++ b/benches/color_bench.rs
@@ -28,9 +28,9 @@ fn blend_f32(src: &Vec4, dst: &Vec4) -> TVec4<f32> {
     let a = src.w;
     let ia = 1.0 - a;
 
-    let r = (src.x * a + dst.x * ia);
-    let g = (src.y * a + dst.y * ia);
-    let b = (src.z * a + dst.z * ia);
+    let r = src.x * a + dst.x * ia;
+    let g = src.y * a + dst.y * ia;
+    let b = src.z * a + dst.z * ia;
     let a_out = 1.0; // or keep dst/ src etc. depending on your model
 
     TVec4::new(r, g, b, a_out)
@@ -41,9 +41,9 @@ fn blend_u8(src: TVec4<u8>, dst: TVec4<u8>) -> TVec4<u8> {
     let a = src.w as f32 / 255.0; // 0.0..=1.0
     let ia = 1.0 - a;
 
-    let cr = (src.x as f32 * a + dst.x as f32 * ia);
-    let cg = (src.y as f32 * a + dst.y as f32 * ia);
-    let cb = (src.z as f32 * a + dst.z as f32 * ia);
+    let cr = src.x as f32 * a + dst.x as f32 * ia;
+    let cg = src.y as f32 * a + dst.y as f32 * ia;
+    let cb = src.z as f32 * a + dst.z as f32 * ia;
     let a_out = 255; // or src.w/other
 
     TVec4::new(cr as u8, cg as u8, cb as u8, a_out)

--- a/benches/min_bench.rs
+++ b/benches/min_bench.rs
@@ -1,4 +1,5 @@
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use std::hint::black_box;
+use criterion::{criterion_group, criterion_main, Criterion};
 
 fn min_with_array(a: u16, b: u16, c: u16) -> u16 {
     [a, b, c].iter().copied().min().unwrap()

--- a/src/material/textured.rs
+++ b/src/material/textured.rs
@@ -316,7 +316,7 @@ mod tests {
     use super::*;
     use crate::drawbuffer::drawbuffer::{CanvasCell, Color};
     use crate::primitivbuffer::primitiv_triangle::PTriangle3D;
-    use crate::primitivbuffer::primitivbuffer::{PointInfo, PrimitivReferences, PrimitiveElements};
+    use crate::primitivbuffer::primitivbuffer::PrimitiveElements;
     use crate::texturebuffer::texture_buffer::TextureBuffer;
     use crate::texturebuffer::RGBA;
     use crate::vertexbuffer::uv_buffer::UVBuffer;

--- a/src/raster/raster_line.rs
+++ b/src/raster/raster_line.rs
@@ -71,8 +71,6 @@ pub fn raster_line<const DEPTHCOUNT: usize>(
 
 #[cfg(test)]
 mod tests {
-    use approx::abs_diff_eq;
-
     use super::*;
 
     #[test]

--- a/src/ttsl/mod.rs
+++ b/src/ttsl/mod.rs
@@ -103,7 +103,7 @@ mod tests {
         // but Instr has no "copy" trait, so we need to do it
         // with a loop ono a vec
         let mut uninit_rest: Vec<Instr> = Vec::with_capacity(256 - bytecode.len());
-        for i in 0..(256 - bytecode.len()) {
+        for _i in 0..(256 - bytecode.len()) {
             uninit_rest.push(Instr {
                 opcode: OP_RET,
                 dst: 0,


### PR DESCRIPTION
Remove unused imports (PointInfo, PrimitivReferences, abs_diff_eq, BenchmarkId). Prefix unused loop variable with underscore in ttsl/mod.rs. Remove unnecessary parentheses in benches/color_bench.rs. Replace deprecated criterion::black_box with std::hint::black_box. Add AGENTS.md with build and workflow guidelines.