### PR TITLE
feat(ttsl): migrate built-ins to tt_* naming and document pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,6 +78,7 @@ instance/
 
 # Sphinx documentation
 docs/_build/
+source/_build/
 
 # PyBuilder
 target/

--- a/demos/ttsl.py
+++ b/demos/ttsl.py
@@ -9,19 +9,21 @@ from textual.binding import Binding
 default_shader_code = """\
 
 # this is the default shader code.
+# Built-in inputs follow the GLSL `gl_*` convention as `tt_*`
+# (see `source/ttsl.md` for the spec).
 
 @ttsl(globals={"time": float, "position": glm.vec3})
-def my_shader(pos: glm.vec2) -> glm.vec3:
+def my_shader(tt_FragCoord: glm.vec2) -> glm.vec3:
     # accessing variables coming from the fragment:
-    uv0: glm.vec2 = ttsl_uv0
-    uv1: glm.vec2 = ttsl_uv1
+    uv0: glm.vec2 = tt_TexCoord0
+    uv1: glm.vec2 = tt_TexCoord1
 
     if uv0.x < 0.5:
         return glm.vec3(1.0, -2.0, 0.0)
     else:
         return glm.vec3(
-            abs(glm.sin(pos.x * 10.0 + ttsl_time / 2.0)),
-            abs(glm.sin(pos.y * 10.0 + ttsl_time / 2.0)),
+            abs(glm.sin(tt_FragCoord.x * 10.0 + tt_Time / 2.0)),
+            abs(glm.sin(tt_FragCoord.y * 10.0 + tt_Time / 2.0)),
             0.5,
         )
 

--- a/dff.py
+++ b/dff.py
@@ -11,7 +11,7 @@ from tt3de.ttsl.compiler import (
 )
 from pyglm import glm
 
-from tt3de.ttsl.decorator import ttsl, ttsl_time, ttsl_uv0, ttsl_uv1
+from tt3de.ttsl.decorator import ttsl, tt_Time, tt_TexCoord0, tt_TexCoord1
 from tt3de.ttsl.enrich import (
     PassPrintConsole,
 )
@@ -24,27 +24,27 @@ console = Console()
 
 
 @ttsl(globals={"time": float, "position": glm.vec3})
-def my_shader(pos: glm.vec2) -> glm.vec3:
+def my_shader(tt_FragCoord: glm.vec2) -> glm.vec3:
     # accessing variables coming from the fragment:
-    uv0: glm.vec2 = ttsl_uv0
-    uv1: glm.vec2 = ttsl_uv1  # noqa
+    uv0: glm.vec2 = tt_TexCoord0
+    uv1: glm.vec2 = tt_TexCoord1  # noqa
 
     if uv0.x < 0.5:
         return glm.vec3(1.0, -2.0, 0.0)
     else:
         return glm.vec3(
-            abs(glm.sin(pos.x * 10.0 + ttsl_time / 2.0)),
-            abs(glm.sin(pos.y * 10.0 + ttsl_time / 2.0)),
+            abs(glm.sin(tt_FragCoord.x * 10.0 + tt_Time / 2.0)),
+            abs(glm.sin(tt_FragCoord.y * 10.0 + tt_Time / 2.0)),
             0.5,
         )
 
 
 @ttsl(globals={"time": float, "position": glm.vec3})
-def my_shader(pos: glm.vec2) -> glm.vec3:  # noqa: F811
+def my_shader(tt_FragCoord: glm.vec2) -> glm.vec3:  # noqa: F811
     # accessing variables coming from the fragment:
     c: float = 0.0  # noqa
 
-    if ttsl_uv0.x < 0.5:
+    if tt_TexCoord0.x < 0.5:
         # c: float = 2.0
         a: float = 2.0  # noqa
         b: float = 1.0
@@ -53,18 +53,18 @@ def my_shader(pos: glm.vec2) -> glm.vec3:  # noqa: F811
         b: float = 1.0
 
     return glm.vec3(
-        abs(glm.sin(ttsl_time / b)),
-        abs(glm.sin(ttsl_time / b)),
+        abs(glm.sin(tt_Time / b)),
+        abs(glm.sin(tt_Time / b)),
         0.5,
     )
 
 
 @ttsl(globals={})
-def my_shader(pos: glm.vec2) -> glm.vec3:  # noqa: F811
-    # calculate a skybox background based on pos (from -1 to 1)
+def my_shader(tt_FragCoord: glm.vec2) -> glm.vec3:  # noqa: F811
+    # calculate a skybox background based on tt_FragCoord (from -1 to 1)
     color_sky: glm.vec3 = glm.vec3(0.2, 0.4, 0.8)
     color_horizon: glm.vec3 = glm.vec3(0.8, 0.9, 1.0)
-    t: float = (pos.y + 1.0) / 2.0
+    t: float = (tt_FragCoord.y + 1.0) / 2.0
     mixed: glm.vec3 = glm.mix(color_sky, color_horizon, t)  # noqa
 
     return mixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,8 @@ dev = [
   "setuptools>=80.9.0",
   "sphinx-book-theme>=1.1.4",
   "sphinx-rtd-theme>=3.0.2",
-  "sphinx>=8.2.3"
+  "sphinx>=8.2.3",
+  "sphinxcontrib-mermaid>=1.0.0"
 ]
 
 [project]

--- a/python/tt3de/ttsl/compiler.py
+++ b/python/tt3de/ttsl/compiler.py
@@ -45,26 +45,28 @@ ALLOWED_IR_TYPES = {
 
 VECTOR_CONSTRUCTORS = {"vec2": IRType.V2, "vec3": IRType.V3, "vec4": IRType.V4}
 
-GLOBAL_VAR_TTSL_TIME = "ttsl_time"
-PIXELVAR_TTSL_UV0: str = "ttsl_uv0"
-PIXELVAR_TTSL_UV1: str = "ttsl_uv1"
-ON_SCREEN_POSITION_VAR_NAME: str = "pos"
+# Built-in TTSL variables follow the OpenGL/GLSL convention `gl_<CamelCase>`,
+# transposed to `tt_<CamelCase>`. Keep these names in sync with `source/ttsl.md`.
+GLOBAL_VAR_TT_TIME: str = "tt_Time"
+PIXELVAR_TT_FRAGCOORD: str = "tt_FragCoord"
+PIXELVAR_TT_TEXCOORD0: str = "tt_TexCoord0"
+PIXELVAR_TT_TEXCOORD1: str = "tt_TexCoord1"
 
 GLOBAL_VAR_SET = {
-    GLOBAL_VAR_TTSL_TIME,
-    PIXELVAR_TTSL_UV0,
-    PIXELVAR_TTSL_UV1,
-    ON_SCREEN_POSITION_VAR_NAME,
+    GLOBAL_VAR_TT_TIME,
+    PIXELVAR_TT_FRAGCOORD,
+    PIXELVAR_TT_TEXCOORD0,
+    PIXELVAR_TT_TEXCOORD1,
 }
 
 GLOBAL_VARIABLES_STR_TYPE = {
-    GLOBAL_VAR_TTSL_TIME: IRType.F32,
+    GLOBAL_VAR_TT_TIME: IRType.F32,
 }
 
 PIXEL_VARIABLES_STR_TYPE = {
-    PIXELVAR_TTSL_UV0: IRType.V2,
-    PIXELVAR_TTSL_UV1: IRType.V2,
-    ON_SCREEN_POSITION_VAR_NAME: IRType.V2,
+    PIXELVAR_TT_FRAGCOORD: IRType.V2,
+    PIXELVAR_TT_TEXCOORD0: IRType.V2,
+    PIXELVAR_TT_TEXCOORD1: IRType.V2,
 }
 
 NATIVE_UNI_OPS_TYPE = {

--- a/python/tt3de/ttsl/decorator.py
+++ b/python/tt3de/ttsl/decorator.py
@@ -3,13 +3,16 @@ import inspect
 from tt3de.ttsl.compiler import TTSLCompilerContext, compile_ttsl
 from pyglm import glm
 
-# Constant accessible in the global uniforms:
-ttsl_time: float = 0.0
+# Built-in TTSL variables. Names mirror the OpenGL `gl_<CamelCase>` convention as
+# `tt_<CamelCase>`; see `source/ttsl.md` for the canonical spec.
 
-# Pixel input variables:
-ttsl_uv0: glm.vec2 = glm.vec2(0.0, 0.0)
-ttsl_uv1: glm.vec2 = glm.vec2(0.0, 0.0)
-screen_pos: glm.vec2 = glm.vec2(0.0, 0.0)
+# Global uniform:
+tt_Time: float = 0.0  # noqa: N816 — built-in name follows OpenGL `gl_*` convention
+
+# Per-fragment (cell) input variables:
+tt_FragCoord: glm.vec2 = glm.vec2(0.0, 0.0)  # noqa: N816
+tt_TexCoord0: glm.vec2 = glm.vec2(0.0, 0.0)  # noqa: N816
+tt_TexCoord1: glm.vec2 = glm.vec2(0.0, 0.0)  # noqa: N816
 
 
 class ShaderDescriptor:

--- a/source/conf.py
+++ b/source/conf.py
@@ -18,6 +18,7 @@ release = "0.1.0"
 extensions = [
     "myst_parser",
     "sphinx.ext.extlinks",
+    "sphinxcontrib.mermaid",
 ]
 
 extlinks = {

--- a/source/ttsl_compiler.md
+++ b/source/ttsl_compiler.md
@@ -3,6 +3,28 @@
 This project contains a full compiler pipeline for Tiny Tiny Shader Language (TTSL).
 The main implementation is in `python/tt3de/ttsl/compiler.py`, and the IR/CFG data model is in `python/tt3de/ttsl/ttsl_assembly.py`.
 
+## Example TTSL source
+
+Built-in inputs follow the OpenGL/GLSL `gl_<CamelCase>` convention,
+transposed to `tt_<CamelCase>` (see [TTSL spec](ttsl.md) for the full table):
+
+- `tt_FragCoord` (`vec2`) — window-space cell coordinate (analogous to `gl_FragCoord.xy`)
+- `tt_TexCoord0`, `tt_TexCoord1` (`vec2`) — interpolated texture coordinates
+- `tt_Time` (`float`) — engine time uniform
+
+The shader function takes `tt_FragCoord` as its parameter; other built-ins are
+implicitly available globals:
+
+```python
+def shade(tt_FragCoord: vec2) -> vec3:
+    pulse: float = sin(tt_Time)
+    color: vec3 = glm.vec3(tt_TexCoord0.x, tt_TexCoord0.y, pulse)
+    if tt_TexCoord0.x > tt_TexCoord0.y:
+        return color
+    else:
+        return glm.mix(color, glm.vec3(0.0, 0.0, 0.0), 0.25)
+```
+
 ## Where compilation starts
 
 The public entry point is:
@@ -26,6 +48,40 @@ The compiler transforms Python-like TTSL source in several stages:
 6. Allocate typed virtual-machine registers (`RegisterAllocatorPass`)
 7. Normalize terminators / block layout
 8. Encode IR into final bytecode (`PassToByteCode`)
+
+## Pipeline diagram
+
+```{mermaid}
+flowchart TD
+    A[TTSL source string] --> B[Parse and front-end IR build<br/>compile_ttsl / compile_ttsl_function]
+    B --> C[CFG construction<br/>build_cfg_from_ir]
+    C --> D[SSA conversion<br/>PassSSARenamer]
+    D --> E[Phi lowering<br/>PassPhiNodeLowering]
+    E --> F[CFG cleanup<br/>CFGSimplifyPass]
+    F --> G[Register allocation<br/>RegisterAllocatorPass]
+    G --> H[Terminator normalization<br/>PassNormalizeTerminators]
+    H --> I[Bytecode emission<br/>PassToByteCode]
+    I --> J[bytes + RegisterSettings]
+```
+
+## Stage-to-source references
+
+- Pipeline orchestrator: `python/tt3de/ttsl/compiler.py` (`all_passes_compilation(...)`)
+- Front-end parsing/AST cleanup and IR generation:
+  - `python/tt3de/ttsl/compiler.py` (`compile_ttsl(...)`, `compile_ttsl_function(...)`)
+  - `python/tt3de/ttsl/compiler.py` (`CleanPythonTreePass`, `TTSLCompilerContext.compile_stmt(...)`, `TTSLCompilerContext.compile_expr(...)`, `TTSLCompilerContext.type_of(...)`)
+- CFG construction:
+  - `python/tt3de/ttsl/ttsl_assembly.py` (`build_cfg_from_ir(...)`)
+- SSA conversion:
+  - `python/tt3de/ttsl/compiler.py` (`PassSSARenamer`, `SSARenamer`)
+- Phi lowering:
+  - `python/tt3de/ttsl/compiler.py` (`PassPhiNodeLowering`)
+- Register allocation:
+  - `python/tt3de/ttsl/compiler.py` (`RegisterAllocatorPass`)
+- Terminator normalization:
+  - `python/tt3de/ttsl/compiler.py` (`PassNormalizeTerminators`)
+- Bytecode lowering:
+  - `python/tt3de/ttsl/compiler.py` (`PassToByteCode`)
 
 ## Front-end: AST to IR
 

--- a/tests/benchs/ttsl/opcode_speedtest.py
+++ b/tests/benchs/ttsl/opcode_speedtest.py
@@ -11,7 +11,7 @@ from tt3de.ttsl.ttsl_assembly import IRType
 from typing import Dict, Any, List
 from tt3de.ttsl.compiler import (
     all_passes_compilation,
-    PIXELVAR_TTSL_UV0,
+    PIXELVAR_TT_TEXCOORD0,
     RegisterSettings,
 )
 from tt3de.tt3de import ttsl_run
@@ -23,12 +23,12 @@ def rversion(regs, bytecode: bytes):
 
 
 SHADER_CODE = """
-def frag(pos: vec2) -> vec3:
-    return vec3(ttsl_uv0.x, ttsl_uv0.y, 0.0)
+def frag(tt_FragCoord: vec2) -> vec3:
+    return vec3(tt_TexCoord0.x, tt_TexCoord0.y, 0.0)
 """
 
 SHADER_CODE2 = """
-def frag(pos: vec2) -> vec3:
+def frag(tt_FragCoord: vec2) -> vec3:
     a:vec3 = vec3(1.0, 2.0, 3.0)
     b:vec3 = vec3(4.0, 5.0, 6.0)
     c:vec3 = a + b
@@ -39,7 +39,7 @@ def frag(pos: vec2) -> vec3:
     c:vec3 = a + b
     c:vec3 = a + b
     c:vec3 = a + b
-    return vec3(ttsl_uv0.x, ttsl_uv0.y, 0.0)
+    return vec3(tt_TexCoord0.x, tt_TexCoord0.y, 0.0)
 """
 
 
@@ -78,7 +78,7 @@ def test_compiled(benchmark: CustomBenchmark, shader_codeidx):
     bytecode, reg_settings = all_passes_compilation(
         all_codes[shader_codeidx], "frag", {}
     )
-    reg_settings.set_variable(PIXELVAR_TTSL_UV0, glm.vec2(0.5, 0.5))
+    reg_settings.set_variable(PIXELVAR_TT_TEXCOORD0, glm.vec2(0.5, 0.5))
     benchmark.context_info["bytecode_size"] = len(bytecode) / 6
     benchmark.run(rversion, reg_settings.get_register_list(), bytecode)
 
@@ -90,7 +90,7 @@ def bench_raw_code(
 ):
 
     # compile the shader first
-    reg_settings.set_variable(PIXELVAR_TTSL_UV0, glm.vec2(0.5, 0.5))
+    reg_settings.set_variable(PIXELVAR_TT_TEXCOORD0, glm.vec2(0.5, 0.5))
     benchmark.context_info["bytecode_size"] = len(bytecode) / 6
     benchmark.run(rversion, reg_settings.get_register_list(), bytecode)
 

--- a/tests/benchs/ttsl/test_bench_ttsl.py
+++ b/tests/benchs/ttsl/test_bench_ttsl.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from tt3de.ttsl.compiler import all_passes_compilation, PIXELVAR_TTSL_UV0
+from tt3de.ttsl.compiler import all_passes_compilation, PIXELVAR_TT_TEXCOORD0
 import pytest
 
 from tt3de.tt3de import ttsl_run
@@ -11,16 +11,16 @@ def rversion(regs, bytecode: bytes):
 
 
 SHADER_CODE = """
-def frag(pos: vec2) -> vec3:
-    return vec3(ttsl_uv0.x, ttsl_uv0.y, 0.0)
+def frag(tt_FragCoord: vec2) -> vec3:
+    return vec3(tt_TexCoord0.x, tt_TexCoord0.y, 0.0)
 """
 
 SHADER_CODE2 = """
-def frag(pos: vec2) -> vec3:
+def frag(tt_FragCoord: vec2) -> vec3:
     a:vec3 = vec3(1.0, 2.0, 3.0)
     b:vec3 = vec3(4.0, 5.0, 6.0)
     c:vec3 = a + b + a + b + a + b + a + b + a + b
-    return vec3(ttsl_uv0.x, ttsl_uv0.y, 0.0)
+    return vec3(tt_TexCoord0.x, tt_TexCoord0.y, 0.0)
 """
 
 
@@ -35,10 +35,10 @@ def test_simple(benchmark, shader_codeidx):
     bytecode, reg_settings = all_passes_compilation(
         all_codes[shader_codeidx], "frag", {}
     )
-    # reg_settings.set_variable(GLOBAL_VAR_TTSL_TIME, 1221.1)
-    reg_settings.set_variable(PIXELVAR_TTSL_UV0, glm.vec2(0.5, 0.5))
-    # reg_settings.set_variable(PIXELVAR_TTSL_UV1, glm.vec2(0.5, 0.5))
-    # reg_settings.set_variable(ON_SCREEN_POSITION_VAR_NAME, glm.vec2(0.5, 0.5))
+    # reg_settings.set_variable(GLOBAL_VAR_TT_TIME, 1221.1)
+    reg_settings.set_variable(PIXELVAR_TT_TEXCOORD0, glm.vec2(0.5, 0.5))
+    # reg_settings.set_variable(PIXELVAR_TT_TEXCOORD1, glm.vec2(0.5, 0.5))
+    # reg_settings.set_variable(PIXELVAR_TT_FRAGCOORD, glm.vec2(0.5, 0.5))
     len(bytecode)
     # from the rar, prepare the registers
     regs = reg_settings.get_register_list()

--- a/tests/tt3de/ttsl/test_passes.py
+++ b/tests/tt3de/ttsl/test_passes.py
@@ -12,10 +12,10 @@ from tt3de.ttsl.compiler import (
     PassNormalizeTerminators,
     PassToByteCode,
     all_passes_compilation,
-    GLOBAL_VAR_TTSL_TIME,
-    PIXELVAR_TTSL_UV0,
-    PIXELVAR_TTSL_UV1,
-    ON_SCREEN_POSITION_VAR_NAME,
+    GLOBAL_VAR_TT_TIME,
+    PIXELVAR_TT_FRAGCOORD,
+    PIXELVAR_TT_TEXCOORD0,
+    PIXELVAR_TT_TEXCOORD1,
 )
 from tt3de.ttsl.ttsl_assembly import build_cfg_from_ir
 
@@ -25,7 +25,7 @@ class Test_SSARenaming(unittest.TestCase):
         src = dedent(
             """
 
-            def my_shader(pos: vec2) -> vec3:
+            def my_shader(tt_FragCoord: vec2) -> vec3:
                 # accessing variables coming from the fragment:
                 return vec3(1.0, -2.0, 0.0)
 
@@ -43,11 +43,11 @@ class Test_SampleCompilation(unittest.TestCase):
         src = dedent(
             """
                 @ttsl(globals={})
-                def my_shader(pos: vec2) -> vec3:  # noqa: F811
-                    # calculate a skybox background based on pos (from -1 to 1)
+                def my_shader(tt_FragCoord: vec2) -> vec3:  # noqa: F811
+                    # calculate a skybox background based on tt_FragCoord (from -1 to 1)
                     color_sky: vec3 = vec3(0.2, 0.4, 0.8)
                     color_horizon: vec3 = vec3(0.8, 0.9, 1.0)
-                    t: float = (pos.y + 1.0) / 2.0
+                    t: float = (tt_FragCoord.y + 1.0) / 2.0
                     mixed: vec3 = color_sky * (1.0 - t) + color_horizon * t
 
                     return mixed
@@ -70,11 +70,11 @@ class Test_SampleCompilation(unittest.TestCase):
         src = dedent(
             """
                 @ttsl(globals={})
-                def my_shader(pos: vec2) -> vec3:  # noqa: F811
-                    # calculate a skybox background based on pos (from -1 to 1)
+                def my_shader(tt_FragCoord: vec2) -> vec3:  # noqa: F811
+                    # calculate a skybox background based on tt_FragCoord (from -1 to 1)
                     color_sky: vec3 = vec3(0.2, 0.4, 0.8)
                     color_horizon: vec3 = vec3(0.8, 0.9, 1.0)
-                    t: float = (pos.y + 1.0) / 2.0
+                    t: float = (tt_FragCoord.y + 1.0) / 2.0
                     mixed: vec3 = color_sky * (1.0 - t) + color_horizon * t
 
                     return mixed
@@ -85,8 +85,8 @@ class Test_SampleCompilation(unittest.TestCase):
         _final_byte_code, reg_settings = all_passes_compilation(
             src, func_name, globals_dict
         )
-        reg_settings.set_variable(GLOBAL_VAR_TTSL_TIME, 1221.1)
-        reg_settings.set_variable(PIXELVAR_TTSL_UV0, glm.vec2(0.5, 0.5))
-        reg_settings.set_variable(PIXELVAR_TTSL_UV1, glm.vec2(0.5, 0.5))
-        reg_settings.set_variable(ON_SCREEN_POSITION_VAR_NAME, glm.vec2(0.5, 0.5))
+        reg_settings.set_variable(GLOBAL_VAR_TT_TIME, 1221.1)
+        reg_settings.set_variable(PIXELVAR_TT_TEXCOORD0, glm.vec2(0.5, 0.5))
+        reg_settings.set_variable(PIXELVAR_TT_TEXCOORD1, glm.vec2(0.5, 0.5))
+        reg_settings.set_variable(PIXELVAR_TT_FRAGCOORD, glm.vec2(0.5, 0.5))
         reg_settings.set_variable("time", 1221.1)

--- a/tests/tt3de/ttsl/test_runttsl.py
+++ b/tests/tt3de/ttsl/test_runttsl.py
@@ -6,7 +6,7 @@ from textwrap import dedent
 import unittest
 
 from tt3de.ttsl.compiler import (
-    PIXELVAR_TTSL_UV0,
+    PIXELVAR_TT_TEXCOORD0,
     PassSSARenamer,
     compile_ttsl,
     PassPhiNodeLowering,
@@ -129,15 +129,15 @@ class Test_RunTTSL(unittest.TestCase):
 
         shader_code = dedent(
             """
-        def frag(pos: vec2) -> vec3:
-            return vec3(ttsl_uv0.x, ttsl_uv0.y, 0.0)
+        def frag(tt_FragCoord: vec2) -> vec3:
+            return vec3(tt_TexCoord0.x, tt_TexCoord0.y, 0.0)
         """
         )
         bytecode, reg_settings = all_passes_compilation(shader_code, "frag", {})
-        # reg_settings.set_variable(GLOBAL_VAR_TTSL_TIME, 1221.1)
-        reg_settings.set_variable(PIXELVAR_TTSL_UV0, glm.vec2(0.5, 0.5))
-        # reg_settings.set_variable(PIXELVAR_TTSL_UV1, glm.vec2(0.5, 0.5))
-        # reg_settings.set_variable(ON_SCREEN_POSITION_VAR_NAME, glm.vec2(0.5, 0.5))
+        # reg_settings.set_variable(GLOBAL_VAR_TT_TIME, 1221.1)
+        reg_settings.set_variable(PIXELVAR_TT_TEXCOORD0, glm.vec2(0.5, 0.5))
+        # reg_settings.set_variable(PIXELVAR_TT_TEXCOORD1, glm.vec2(0.5, 0.5))
+        # reg_settings.set_variable(PIXELVAR_TT_FRAGCOORD, glm.vec2(0.5, 0.5))
 
         # from the rar, prepare the registers
         regs = reg_settings.get_register_list()

--- a/uv.lock
+++ b/uv.lock
@@ -1174,6 +1174,21 @@ wheels = [
 ]
 
 [[package]]
+name = "sphinxcontrib-mermaid"
+version = "2.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jinja2" },
+    { name = "pyyaml" },
+    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/75/3a1cc926da8c563c58ddc124a7b3fe5ccadcae96c96e3a6f8ac3653a210a/sphinxcontrib_mermaid-2.0.2.tar.gz", hash = "sha256:f09576c78ca93fa0e3034fd9c45aaffa7c44ab449de9c43b8b8d262afe52bc66", size = 19265, upload-time = "2026-05-05T13:59:02.959Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/8d/93be7e0f7fa915a576859b3bfac7a7baa3303181c44d7db7eefbd3e8a69f/sphinxcontrib_mermaid-2.0.2-py3-none-any.whl", hash = "sha256:d862e514991279fb4816302c5cfe167d2557bf3ce7125ae0cb47dac80a0f46ce", size = 14094, upload-time = "2026-05-05T13:59:01.585Z" },
+]
+
+[[package]]
 name = "sphinxcontrib-qthelp"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1238,6 +1253,7 @@ dev = [
     { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "sphinx-book-theme" },
     { name = "sphinx-rtd-theme" },
+    { name = "sphinxcontrib-mermaid" },
 ]
 
 [package.metadata]
@@ -1266,6 +1282,7 @@ dev = [
     { name = "sphinx", specifier = ">=8.2.3" },
     { name = "sphinx-book-theme", specifier = ">=1.1.4" },
     { name = "sphinx-rtd-theme", specifier = ">=3.0.2" },
+    { name = "sphinxcontrib-mermaid", specifier = ">=1.0.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
Align compiler/decorator built-in identifiers with GLSL-style tt_* names and update demos/tests/docs, including Mermaid pipeline rendering support for the compiler docs.