### PR TITLE
feat: remove legacy_layers and finalize two-pass rendering

### DIFF
--- a/.evolution/evol-lighting.md
+++ b/.evolution/evol-lighting.md
@@ -16,7 +16,7 @@ related:
 
 ## Summary
 
-Add real light capability to the tt3de engine. Introduce a **LightBuffer** — a new engine-level buffer holding a fixed-capacity set of typed light sources (ambient, directional, point) — and TTSL **accessor opcodes** that let shaders query individual light properties by index. The LightBuffer stores light data in **world space** (user-friendly); the engine **auto-transforms** positions and directions to **view space** each frame before material application, following the OpenGL `glLightfv` convention. Provide a **reference TTSL shader** demonstrating ambient illumination, Lambert diffuse from a directional light, and point-light distance attenuation — all computed in view space using `tt_Normal`, `tt_ViewPos`, and the light accessors. Spot lights, shadows, and specular effects are explicitly excluded from this first iteration.
+Add real light capability to the tt3de engine. Introduce a **LightBuffer** — a new engine-level buffer holding a fixed-capacity set of typed light sources (ambient, directional, point) — and TTSL **accessor opcodes** that let shaders query individual light properties by index. The LightBuffer stores light data in **world space** (user-friendly); the engine **auto-transforms** positions and directions to **view space** each frame before material application, following the OpenGL `glLightfv` convention. The integration follows the current drawing model: opaque shading into `opaque_db`, then transparent shading from `transparent_db` composited onto opaque canvas. Provide a **reference TTSL shader** demonstrating ambient illumination, Lambert diffuse from a directional light, and point-light distance attenuation — all computed in view space using `tt_Normal`, `tt_ViewPos`, and the light accessors. Spot lights, shadows, and specular effects are explicitly excluded from this first iteration.
 
 ## Motivation and context
 
@@ -124,7 +124,9 @@ None. Existing apps that do not create a `LightBufferPy` are unaffected. The ren
 |-----------|--------------|
 | Light sources | None — no concept in the engine |
 | Shader data access | TextureBuffer via `tt_texture(slot, uv)` opcode; user uniforms via register seeds |
-| `RustRenderContext` | Holds `transform_buffer`, `geometry_buffer`, `primitive_buffer`, `drawing_buffer`, `texture_buffer`, `material_buffer` |
+| Drawing pipeline | Two-pass routing via `pass_filter`: raster/apply opaque first, then raster/apply transparent |
+| `DrawingBufferPy` | Holds `opaque_db: DrawBuffer<1, f32>` and `transparent_db: DrawBuffer<1, f32>`; transparent composite writes onto opaque canvas |
+| `RustRenderContext` | Holds `transform_buffer`, `geometry_buffer`, `primitive_buffer`, `drawing_buffer`, `texture_buffer`, `material_buffer`; orchestrates pass-filtered raster/material calls |
 | `run_ttsl` / `ShaderMaterial::render_mat` | Receives `&TextureBuffer` via `TtslTextureEnv` trait; no light env |
 | `TransformPack` | Has unused `environment_light: Vec3` field — placeholder, not wired |
 
@@ -251,10 +253,12 @@ This is a one-time migration but future-proof against additional env types (simp
 ### Phase 3: Engine integration
 
 1. **`RustRenderContext`**: Add a `light_buffer` field (defaulting to an empty buffer or `None`).
-2. **Per-frame view-space update**: In the render path, after the camera's view matrix is set and before material application, call `light_buffer.update_view_space(&transform_pack.view_matrix_3d)`. This mirrors how `glLightfv` transformed light data by the active modelview matrix.
-3. **`ShaderMaterial::render_mat`**: Construct a `TtslEnv` with both `tex` and `light` pointers, and pass it to `run_ttsl`. The conversion from `&LightBuffer` to `&dyn TtslLightEnv` happens here — no generics on `ShaderMaterial` are needed.
-4. **No changes to `RenderMaterial` trait or `apply_material_on`**: Unlike `TextureBuffer`, the LightBuffer is only consumed inside the TTSL VM (`run_ttsl` → `exec_opcode`). Neither the `RenderMaterial` trait nor the `apply_material` dispatch chain needs to carry it. This significantly reduces the blast radius vs threading it through the entire material pipeline.
-5. **Python `RustRenderContext`**: Expose `light_buffer` property for assignment.
+2. **Per-frame view-space update**: In the render path, after the camera's view matrix is set and before the first material pass, call `light_buffer.update_view_space(&transform_pack.view_matrix_3d)`. This mirrors how `glLightfv` transformed light data by the active modelview matrix.
+3. **Pass-model alignment**: Keep one view-space snapshot per frame and reuse it for both shading passes (`pass_filter="opaque"` and `pass_filter="transparent"`). No per-pass re-transform is needed unless camera/lights mutate mid-frame.
+4. **`ShaderMaterial::render_mat`**: Construct a `TtslEnv` with both `tex` and `light` pointers, and pass it to `run_ttsl`. The conversion from `&LightBuffer` to `&dyn TtslLightEnv` happens here — no generics on `ShaderMaterial` are needed.
+5. **No changes to `RenderMaterial` trait or apply-dispatch shape**: Unlike `TextureBuffer`, the LightBuffer is consumed inside the TTSL VM (`run_ttsl` → `exec_opcode`). The material dispatch path (`apply_material_on` for opaque and `apply_material_transparent_on` for transparent) stays structurally unchanged.
+6. **Transparent composite semantics unchanged**: Lighting affects shader output, but transparent compositing remains front-color blend + optional glyph replacement over opaque canvas according to `BlendMode` and `GlyphPolicy`.
+7. **Python `RustRenderContext`**: Expose `light_buffer` property for assignment.
 
 ### Phase 4: Compiler support
 
@@ -290,7 +294,8 @@ This is a one-time migration but future-proof against additional env types (simp
 - `src/material/shader_material.rs` — construct `TtslEnv` and pass to `run_ttsl` (only production call site affected)
 - *(No changes to `RenderMaterial` trait, `apply_material_on`, or `apply_material` — LightBuffer is consumed only inside the VM)*
 - `src/lib.rs` — expose `LightBufferPy`, register `lightbuffer` module
-- `python/tt3de/render_context_rust.py` — call `update_view_space` in render path, expose `light_buffer`
+- `python/tt3de/render_context_rust.py` — call `update_view_space` once per frame before material passes; expose `light_buffer`
+- `src/primitiv_building/mod.rs` — keep pass-filtered apply path wired (opaque + transparent) while threading LightBuffer access through shader execution
 - `python/tt3de/ttsl/ttisa/low_level_def.py` — new opcode generators for light accessors
 - `python/tt3de/ttsl/ttsl_assembly.py` — new `OpCodes` members
 - `python/tt3de/ttsl/compiler.py` — light accessor built-in functions
@@ -321,6 +326,8 @@ This is a one-time migration but future-proof against additional env types (simp
 - **Compiler tests** (Python): Compile shaders using `tt_lightCount()`, `tt_lightColor(0)`, etc. Verify bytecode generation succeeds.
 - **E2E tests** (Python): A shader that reads light properties and returns them as pixel colors; verify output matches the configured LightBuffer after view-space transform.
 - **Integration test**: Full render pipeline with a LightBuffer attached; verify that a triangle facing the directional light is brighter than one facing away.
+- **Pass parity test**: Attach LightBuffer and render one opaque + one transparent primitive using the same shader. Verify both passes see the same light values and transparent output composites correctly over opaque output.
+- **Opaque serial/parallel parity**: With LightBuffer-enabled shaders, assert `apply_material_py` and `apply_material_py_parallel(pass_filter="opaque")` produce equivalent canvas output.
 - **Regression**: All existing tests pass. Shaders that don't use light accessors must be unaffected.
 
 ## Complexity and scope
@@ -343,6 +350,7 @@ This is a one-time migration but future-proof against additional env types (simp
 
 - **Light accessor opcodes**: For a reference shader with 3 lights and ~5 accessors per light = ~15 opcode dispatches per pixel. Each is a bounds-checked array index + field read. For 12K cells × 15 = ~180K accessor calls/frame. Sub-millisecond on modern CPUs.
 - **Per-frame view-space update** (`update_view_space`): 16 lights × 2 matrix-vector multiplies (direction + position) = 32 operations per frame. Negligible.
+- **Two-pass shading impact**: Light accessor cost applies wherever shader materials run; transparent pass pays the same per-fragment accessor overhead before front-color compositing.
 - **LightBuffer memory**: 16 slots × ~120 bytes (world + view fields) ≈ 1.9 KB. L1 cache.
 - **`run_ttsl` signature**: The `tex` and `light` envs are bundled into a single `&TtslEnv` pointer (same size as the old single-optional parameter — unchanged register pressure).
 
@@ -360,6 +368,7 @@ This is a one-time migration but future-proof against additional env types (simp
 - **TTSL loop support**: TTSL already supports `while` loops (not `for`). The reference shader can iterate lights with `i = 0; while i < tt_lightCount(): ... i = i + 1`. The doc's earlier draft was too pessimistic — this is not a risk, just verify `i32` comparison operators work in the compiled output.
 - **HDR and clamping**: Light color × albedo can exceed 1.0. The reference shader clamps to [0, 1] before output. The convention is: shaders are responsible for tone mapping / clamping.
 - **Directional light direction convention**: In OpenGL, `GL_POSITION` with `w=0` is a direction *toward* the light (not from the light). The reference shader should document whether `tt_lightDirection` is "toward light" or "from light" — suggest "toward light" (positive dot product with N means lit).
+- **Transparent pass interactions**: Lighting is evaluated before transparent compositing, but visual results still depend on blend mode and glyph policy (`preserve_existing` vs `replace_from_shader`). Document this clearly in demo and docs to avoid confusion when lit transparent layers look muted.
 - **Opcode numbering stability**: Adding opcodes shifts subsequent indices. Not a problem today (no bytecode persistence).
 - **`TransformPack.environment_light`**: Existing unused field. Consider removing or repurposing it now that a proper LightBuffer exists, to avoid confusion.
 

--- a/.evolution/evol-remove-legacy-layers.md
+++ b/.evolution/evol-remove-legacy-layers.md
@@ -1,0 +1,142 @@
+# Evolution: Remove legacy `legacy_layers` compatibility path
+
+```yaml
+id: evol-remove-legacy-layers
+status: proposed
+created: 2026-05-14
+updated: 2026-05-14
+authors: []
+supersedes:
+  - evol-transparency-depth-layers
+superseded-by: ""
+related:
+  - .evolution/evol-transparency-depth-layers.md
+  - src/drawbuffer/mod.rs
+  - src/drawbuffer/drawbuffer.rs
+  - src/raster/mod.rs
+  - src/primitiv_building/mod.rs
+  - python/tt3de/render_context_rust.py
+  - source/low_level_api.rst
+  - source/high_level_api.rst
+```
+
+## Summary
+
+Remove the temporary `legacy_layers=True` compatibility mode and make the two-pass architecture the only rendering path.
+
+After this evolution, `DrawingBufferPy` no longer exposes the legacy `DrawBuffer<2, f32>` flow. The engine always renders using:
+
+1. opaque pass (`DrawBuffer<1, f32>`, depth write on),
+2. transparent pass (`DrawBuffer<1, f32>`, depth write off),
+3. transparent front-color compositing with `BlendMode` and `GlyphPolicy`.
+
+## Motivation and context
+
+`legacy_layers` was introduced as a migration bridge while moving from K-buffer-like layering to explicit opaque + transparent passes. It has now served its purpose:
+
+- It adds maintenance overhead (dual codepaths in Rust and Python).
+- It complicates tests and docs with branch-specific behavior.
+- It slows feature work because every rendering change must preserve obsolete semantics.
+
+Keeping both paths increases risk of regressions and API confusion. Removing `legacy_layers` consolidates behavior and simplifies future transparency work.
+
+## Goals
+
+- Remove `legacy_layers` argument and internal branching from `DrawingBufferPy`.
+- Remove legacy `DrawBuffer<2, f32>` usage in runtime render flow.
+- Keep public transparency workflow stable (`transparent` primitive flag, per-material `blend_mode`, `glyph_policy`).
+- Update docs and tests to reflect one canonical rendering model.
+
+## Non-goals
+
+- Introducing transparent primitive sorting in this milestone.
+- Changing `BlendMode` equations or adding new blend variants.
+- Changing default `transparent=False` primitive qualification semantics.
+
+## User-visible functionality
+
+- **Breaking change:** `DrawingBufferPy(..., legacy_layers=...)` is removed.
+- Default behavior becomes the current `legacy_layers=False` path.
+- Any code relying on old layered depth stack behavior is no longer supported.
+
+## Technical approach
+
+### 1. Remove legacy fields and branches
+
+- In `src/drawbuffer/mod.rs`, remove:
+  - `legacy_layers` state,
+  - legacy `db: DrawBuffer<2, f32>` runtime dependency,
+  - conditional branches selecting legacy vs new path.
+- Keep only:
+  - `opaque_db: DrawBuffer<1, f32>`,
+  - `transparent_db: DrawBuffer<1, f32>`.
+
+### 2. Normalize render pipeline calls
+
+- In `src/raster/mod.rs`, keep pass-filtered raster API as the sole path.
+- In `src/primitiv_building/mod.rs`, keep:
+  - opaque material resolve on `opaque_db`,
+  - transparent composite from `transparent_db` to opaque canvas.
+- In `python/tt3de/render_context_rust.py`, remove conditional flow and always execute dual pass.
+
+### 3. Remove compatibility/deprecation behavior
+
+- Delete deprecation warning logic tied to `legacy_layers=True`.
+- Remove mention of transitional compatibility in constructor docstrings and comments.
+
+### 4. Cleanup and simplify tests
+
+- Update tests to assert only single-pass-per-buffer semantics (`L=1` per pass).
+- Remove tests that explicitly exercise legacy layered resolve behavior.
+
+## Usability and documentation
+
+- Update `source/low_level_api.rst` to remove compatibility narrative and present only the dual-pass model.
+- Update `source/high_level_api.rst` examples so they do not mention `legacy_layers`.
+- Add a concise migration note:
+  - remove `legacy_layers` kwargs from user code,
+  - validate scenes that previously depended on two-layer stacking artifacts.
+
+## Testability
+
+- Rust:
+  - `cargo check --all-targets`
+  - `cargo test`
+  - drawbuffer/raster/material tests updated for single canonical path.
+- Python:
+  - `$env:PYTHONPATH='.'; uv run pytest`
+  - targeted coverage for transparent pass behavior and blend dispatch.
+
+## Complexity and scope
+
+- Scope: medium.
+- Estimated touchpoints:
+  - `src/drawbuffer/mod.rs`
+  - `src/primitiv_building/mod.rs`
+  - `src/raster/mod.rs`
+  - `python/tt3de/render_context_rust.py`
+  - relevant tests and docs.
+- Primary risk is test churn and accidental reliance on legacy buffer assumptions.
+
+## Risks and open questions
+
+- Some demos/tests may still implicitly depend on historical two-layer behavior.
+- Removal should be coordinated with a short migration note in release/changelog.
+- If any consumer still requires legacy behavior, they should pin to the prior release rather than preserving dual runtime paths.
+
+## Decision record
+
+- **Status:** proposed
+- **Resolution target:**
+  1. Remove `legacy_layers` API and implementation branches.
+  2. Keep dual-pass `DrawBuffer<1, f32>` architecture as the only supported path.
+  3. Update tests/docs in the same PR.
+
+## References
+
+- `.evolution/evol-transparency-depth-layers.md`
+- `src/drawbuffer/mod.rs`
+- `src/drawbuffer/drawbuffer.rs`
+- `src/raster/mod.rs`
+- `src/primitiv_building/mod.rs`
+- `python/tt3de/render_context_rust.py`

--- a/demos/2d/bouncing_clock.py
+++ b/demos/2d/bouncing_clock.py
@@ -1,5 +1,19 @@
 # -*- coding: utf-8 -*-
-from typing import List
+"""
+Bouncing digital clock using TTSL texture sampling for glyph sprites.
+
+The clock keeps movement/collision and HH:MM:SS updates in Python, while each
+digit/colon quad now uses a compiled TTSL shader (`clock_tex`) to sample a
+per-character texture.
+
+Run:
+    uv run python demos/2d/bouncing_clock.py
+"""
+
+# -*- coding: utf-8 -*-
+from pathlib import Path
+from textwrap import dedent
+from typing import Dict, List
 
 import datetime
 from pyglm import glm
@@ -7,19 +21,104 @@ from textual.widgets import (
     Header,
 )
 from textual.app import App, ComposeResult
-from tt3de.asset_fastloader import MaterialPerfab
+from tt3de.asset_fastloader import DefaultSpriteSheet32px, MaterialPerfab
+from tt3de.asset_load import load_bmp
 from tt3de.glm_camera import ViewportScaleMode
+from tt3de.richtexture import ImageTexture
 from tt3de.textual.debugged_view import DebuggedView
 from tt3de.textual_standalone import TT3DViewStandAlone
-from tt3de.tt3de import find_glyph_indices_py
+from tt3de.tt3de import find_glyph_indices_py, materials  # type: ignore[reportMissingImports]
 from tt3de.tt_2dnodes import TT2DNode, TT2DUnitSquare
+from tt3de.ttsl.compiler import all_passes_compilation
+
+SPRITE_SIZE_PX = 32
+SHADER_UNIFORM_TEXIDX = "u_TextureIndex"
+
+SHADER_SRC = dedent(
+    """
+    def clock_tex(tt_TexCoord0: vec2, tt_TexCoord1: vec2) -> tuple[vec4, vec4, int]:
+        sampled_top: vec4 = tt_texture(u_TextureIndex, tt_TexCoord0)
+        sampled_bottom: vec4 = tt_texture(u_TextureIndex, tt_TexCoord1)
+        # Shader materials write final colors directly (no alpha compositing pass), so
+        # each half-cell must black out its own transparent texels to avoid key-color
+        # fringes from the sprite sheet at glyph boundaries.
+        if sampled_top.w < 0.5:
+            top_rgb: vec4 = vec4(0.0, 0.0, 0.0, 1.0)
+        else:
+            top_rgb: vec4 = vec4(sampled_top.x, sampled_top.y, sampled_top.z, 1.0)
+        if sampled_bottom.w < 0.5:
+            bottom_rgb: vec4 = vec4(0.0, 0.0, 0.0, 1.0)
+        else:
+            bottom_rgb: vec4 = vec4(sampled_bottom.x, sampled_bottom.y, sampled_bottom.z, 1.0)
+        return (top_rgb, bottom_rgb, 0)
+    """
+)
+
+
+def _sprite_to_texture_data(
+    sprite_sheet: ImageTexture, sprite_idx: int
+) -> tuple[int, int, list[tuple[int, int, int, int]]]:
+    """Extract one 32x32 sprite tile as a standalone texture payload."""
+    cols = sprite_sheet.image_width // SPRITE_SIZE_PX
+    tile_row_from_bottom = cols - (sprite_idx // cols) - 1
+    tile_col = sprite_idx % cols
+    start_x = tile_col * SPRITE_SIZE_PX
+    start_y = tile_row_from_bottom * SPRITE_SIZE_PX
+
+    tile_pixels: list[tuple[int, int, int, int]] = []
+    for y in range(start_y, start_y + SPRITE_SIZE_PX):
+        row = sprite_sheet.img_data[y]
+        tile_pixels.extend(row[start_x : start_x + SPRITE_SIZE_PX])
+
+    return (SPRITE_SIZE_PX, SPRITE_SIZE_PX, tile_pixels)
 
 
 class BouncingClock(TT3DViewStandAlone):
-    def initialize(self):
-        self.rc.texture_buffer, self.rc.material_buffer, self.sprite_sheet_map = (
-            MaterialPerfab.rust_set_0(with_sprite_map=True)
+    def initialize(self) -> None:
+        # Keep prefab slot-0 as a static material; shader materials are appended for digits.
+        self.rc.texture_buffer, self.rc.material_buffer = MaterialPerfab.rust_set_0()
+        self._bytecode, reg_settings = all_passes_compilation(
+            SHADER_SRC,
+            "clock_tex",
+            {SHADER_UNIFORM_TEXIDX: int},
         )
+        half_upper_block = find_glyph_indices_py("▀")
+        self.shader_mat_by_sprite: Dict[DefaultSpriteSheet32px, int] = {}
+
+        sprite_sheet_path = (
+            Path(__file__).resolve().parents[2] / "models" / "sprite_sheet_32px.bmp"
+        )
+        with sprite_sheet_path.open("rb") as fin:
+            sprite_sheet_img = ImageTexture(
+                load_bmp(fin, alpha=255, transparent_colors=[(0, 0, 255)])
+            )
+
+        sprite_texture_by_sprite: Dict[DefaultSpriteSheet32px, int] = {}
+        for sprite in DefaultSpriteSheet32px:
+            w, h, chained_data = _sprite_to_texture_data(sprite_sheet_img, sprite.value)
+            tex_idx = self.rc.texture_buffer.add_texture(
+                w,
+                h,
+                chained_data,
+                False,
+                False,
+            )
+            sprite_texture_by_sprite[sprite] = tex_idx
+
+        for sprite in DefaultSpriteSheet32px:
+            shader_regs = reg_settings.fork()
+            shader_regs.set_variable(
+                SHADER_UNIFORM_TEXIDX, sprite_texture_by_sprite[sprite]
+            )
+            mat_idx = self.rc.material_buffer.add_shader(
+                materials.ShaderPy(
+                    self._bytecode,
+                    default_glyph=half_upper_block,
+                    register_seed=shader_regs.get_register_list(),
+                )
+            )
+            self.shader_mat_by_sprite[sprite] = mat_idx
+
         self.camera.set_zoom_2D(0.12)
         self.camera.set_viewport_scale_mode(ViewportScaleMode.FILL)
 
@@ -39,14 +138,18 @@ class BouncingClock(TT3DViewStandAlone):
         self.digit_nodes: List[TT2DUnitSquare] = []
 
         char_pos_x = 0.0
-        for i, ch in enumerate(self.clock_chars):
-            mat_id = self.sprite_sheet_map.map_string_to_matidx(ch)[0]
-            left_shift = 0 if ch.isdigit() else -0.2
+        for ch in self.clock_chars:
+            sprite = DefaultSpriteSheet32px.convert_string_to_sprites(ch)[0]
+            mat_id = self.shader_mat_by_sprite[sprite]
+            char_width = 0.8 if ch.isdigit() else 0.4
             digit_point = TT2DUnitSquare(
                 material_id=mat_id,
             )
-            digit_point.position = glm.vec3(char_pos_x + left_shift, 0.0, 0.0)
-            char_pos_x += 0.8 if ch.isdigit() else 0.4
+            # Shader materials don't alpha-blend transparent texels like BaseTexturePy,
+            # so keep quads non-overlapping to avoid visible character collisions.
+            digit_point.scale = glm.vec2(char_width, 1.0)
+            digit_point.position = glm.vec3(char_pos_x, 0.0, 0.0)
+            char_pos_x += char_width
 
             self.digit_nodes.append(digit_point)
             self.clock_node.add_child(digit_point)
@@ -72,7 +175,7 @@ class BouncingClock(TT3DViewStandAlone):
         self.root2Dnode.add_child(self.clock_node)
         self.rc.append_root(self.root2Dnode)
 
-    def update_step(self, delta_time: float):
+    def update_step(self, delta_time: float) -> None:
         # check for border collision and change direction if needed
         if self.clock_node.get_position().x + self.clock_width > self.border_x_dist:
             self.direction = glm.normalize(
@@ -103,7 +206,15 @@ class BouncingClock(TT3DViewStandAlone):
             now_str = now_str.ljust(len(self.clock_chars))
 
         for i, (ch, mat_id) in enumerate(
-            zip(now_str, self.sprite_sheet_map.map_string_to_matidx(now_str))
+            zip(
+                now_str,
+                [
+                    self.shader_mat_by_sprite[sprite]
+                    for sprite in DefaultSpriteSheet32px.convert_string_to_sprites(
+                        now_str
+                    )
+                ],
+            )
         ):
             if self.clock_chars[i] != ch:
                 self.clock_chars[i] = ch

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dev = [
   "setuptools>=80.9.0",
   "sphinx-book-theme>=1.1.4",
   "sphinx-rtd-theme>=3.0.2",
-  "sphinx>=8.2.3",
+  "sphinx>=8.2.3"
 ]
 
 [project]

--- a/python/tt3de/render_context_rust.py
+++ b/python/tt3de/render_context_rust.py
@@ -44,7 +44,6 @@ class RustRenderContext:
         texture_buffer_size=32,
         material_buffer_size=32,
         material_parallel_threads: int | None = 8,
-        legacy_layers: bool = True,
     ):
         """
         Create buffers for Rust-backed rasterization.
@@ -58,7 +57,6 @@ class RustRenderContext:
         if material_parallel_threads is not None and material_parallel_threads < 1:
             material_parallel_threads = None
         self._material_parallel_threads = material_parallel_threads
-        self.legacy_layers = legacy_layers
 
         self.texture_buffer = TextureBufferPy(texture_buffer_size)
         self.material_buffer = MaterialBufferPy(material_buffer_size)
@@ -77,7 +75,6 @@ class RustRenderContext:
                 if self._material_parallel_threads is None
                 else self._material_parallel_threads
             ),
-            legacy_layers=self.legacy_layers,
         )
 
         self.global_bit_size = 4
@@ -98,7 +95,6 @@ class RustRenderContext:
                     if self._material_parallel_threads is None
                     else self._material_parallel_threads
                 ),
-                legacy_layers=self.legacy_layers,
             )
             # self.drawing_buffer.set_bit_size_front(self.global_bit_size,self.global_bit_size,self.global_bit_size)
             # self.drawing_buffer.set_bit_size_back(self.global_bit_size,self.global_bit_size,self.global_bit_size)
@@ -130,66 +126,45 @@ class RustRenderContext:
             self.drawing_buffer,
             self.primitive_buffer,
         )
-        if self.legacy_layers:
-            raster_all_py(
-                self.primitive_buffer, self.vertex_buffer, self.drawing_buffer
-            )
-            if self._material_parallel_threads is None:
-                apply_material_py(
-                    self.material_buffer,
-                    self.texture_buffer,
-                    self.vertex_buffer,
-                    self.primitive_buffer,
-                    self.drawing_buffer,
-                )
-            else:
-                apply_material_py_parallel(
-                    self.material_buffer,
-                    self.texture_buffer,
-                    self.vertex_buffer,
-                    self.primitive_buffer,
-                    self.drawing_buffer,
-                )
-        else:
-            raster_all_py(
-                self.primitive_buffer,
-                self.vertex_buffer,
-                self.drawing_buffer,
-                pass_filter="opaque",
-            )
-            if self._material_parallel_threads is None:
-                apply_material_py(
-                    self.material_buffer,
-                    self.texture_buffer,
-                    self.vertex_buffer,
-                    self.primitive_buffer,
-                    self.drawing_buffer,
-                    pass_filter="opaque",
-                )
-            else:
-                apply_material_py_parallel(
-                    self.material_buffer,
-                    self.texture_buffer,
-                    self.vertex_buffer,
-                    self.primitive_buffer,
-                    self.drawing_buffer,
-                    pass_filter="opaque",
-                )
-
-            raster_all_py(
-                self.primitive_buffer,
-                self.vertex_buffer,
-                self.drawing_buffer,
-                pass_filter="transparent",
-            )
+        raster_all_py(
+            self.primitive_buffer,
+            self.vertex_buffer,
+            self.drawing_buffer,
+            pass_filter="opaque",
+        )
+        if self._material_parallel_threads is None:
             apply_material_py(
                 self.material_buffer,
                 self.texture_buffer,
                 self.vertex_buffer,
                 self.primitive_buffer,
                 self.drawing_buffer,
-                pass_filter="transparent",
+                pass_filter="opaque",
             )
+        else:
+            apply_material_py_parallel(
+                self.material_buffer,
+                self.texture_buffer,
+                self.vertex_buffer,
+                self.primitive_buffer,
+                self.drawing_buffer,
+                pass_filter="opaque",
+            )
+
+        raster_all_py(
+            self.primitive_buffer,
+            self.vertex_buffer,
+            self.drawing_buffer,
+            pass_filter="transparent",
+        )
+        apply_material_py(
+            self.material_buffer,
+            self.texture_buffer,
+            self.vertex_buffer,
+            self.primitive_buffer,
+            self.drawing_buffer,
+            pass_filter="transparent",
+        )
 
     def to_textual_2(self, region: Region) -> List[Strip]:
         res = self.drawing_buffer.to_textual_2(

--- a/python/tt3de/render_context_rust.py
+++ b/python/tt3de/render_context_rust.py
@@ -44,8 +44,10 @@ class RustRenderContext:
         texture_buffer_size=32,
         material_buffer_size=32,
         material_parallel_threads: int | None = 8,
+        legacy_layers: bool = True,
     ):
-        """Create buffers for Rust-backed rasterization.
+        """
+        Create buffers for Rust-backed rasterization.
 
         ``material_parallel_threads``: ``None`` runs the material pass on one thread;
         a positive integer builds a per-context Rayon pool with that many threads (default ``8``).
@@ -56,6 +58,7 @@ class RustRenderContext:
         if material_parallel_threads is not None and material_parallel_threads < 1:
             material_parallel_threads = None
         self._material_parallel_threads = material_parallel_threads
+        self.legacy_layers = legacy_layers
 
         self.texture_buffer = TextureBufferPy(texture_buffer_size)
         self.material_buffer = MaterialBufferPy(material_buffer_size)
@@ -70,8 +73,11 @@ class RustRenderContext:
             max_row=self.height,
             max_col=self.width,
             material_parallel_threads=(
-                0 if self._material_parallel_threads is None else self._material_parallel_threads
+                0
+                if self._material_parallel_threads is None
+                else self._material_parallel_threads
             ),
+            legacy_layers=self.legacy_layers,
         )
 
         self.global_bit_size = 4
@@ -92,6 +98,7 @@ class RustRenderContext:
                     if self._material_parallel_threads is None
                     else self._material_parallel_threads
                 ),
+                legacy_layers=self.legacy_layers,
             )
             # self.drawing_buffer.set_bit_size_front(self.global_bit_size,self.global_bit_size,self.global_bit_size)
             # self.drawing_buffer.set_bit_size_back(self.global_bit_size,self.global_bit_size,self.global_bit_size)
@@ -123,32 +130,65 @@ class RustRenderContext:
             self.drawing_buffer,
             self.primitive_buffer,
         )
-        # raster all the primitives in the drawing buffer
-        raster_all_py(self.primitive_buffer, self.vertex_buffer, self.drawing_buffer)
+        if self.legacy_layers:
+            raster_all_py(
+                self.primitive_buffer, self.vertex_buffer, self.drawing_buffer
+            )
+            if self._material_parallel_threads is None:
+                apply_material_py(
+                    self.material_buffer,
+                    self.texture_buffer,
+                    self.vertex_buffer,
+                    self.primitive_buffer,
+                    self.drawing_buffer,
+                )
+            else:
+                apply_material_py_parallel(
+                    self.material_buffer,
+                    self.texture_buffer,
+                    self.vertex_buffer,
+                    self.primitive_buffer,
+                    self.drawing_buffer,
+                )
+        else:
+            raster_all_py(
+                self.primitive_buffer,
+                self.vertex_buffer,
+                self.drawing_buffer,
+                pass_filter="opaque",
+            )
+            if self._material_parallel_threads is None:
+                apply_material_py(
+                    self.material_buffer,
+                    self.texture_buffer,
+                    self.vertex_buffer,
+                    self.primitive_buffer,
+                    self.drawing_buffer,
+                    pass_filter="opaque",
+                )
+            else:
+                apply_material_py_parallel(
+                    self.material_buffer,
+                    self.texture_buffer,
+                    self.vertex_buffer,
+                    self.primitive_buffer,
+                    self.drawing_buffer,
+                    pass_filter="opaque",
+                )
 
-        # apply_material_py(
-        #     self.material_buffer,
-        #     self.texture_buffer,
-        #     self.vertex_buffer,
-        #     self.primitive_buffer,
-        #     self.drawing_buffer,
-        # )
-        # material pass (parallel uses per-context Rayon pool on DrawingBufferPy)
-        if self._material_parallel_threads is None:
+            raster_all_py(
+                self.primitive_buffer,
+                self.vertex_buffer,
+                self.drawing_buffer,
+                pass_filter="transparent",
+            )
             apply_material_py(
                 self.material_buffer,
                 self.texture_buffer,
                 self.vertex_buffer,
                 self.primitive_buffer,
                 self.drawing_buffer,
-            )
-        else:
-            apply_material_py_parallel(
-                self.material_buffer,
-                self.texture_buffer,
-                self.vertex_buffer,
-                self.primitive_buffer,
-                self.drawing_buffer,
+                pass_filter="transparent",
             )
 
     def to_textual_2(self, region: Region) -> List[Strip]:

--- a/python/tt3de/tt_2dnodes.py
+++ b/python/tt3de/tt_2dnodes.py
@@ -199,6 +199,7 @@ class WithMaterialID(DirtyProcessor):
         super().__init__(**kwargs)
         self.material_id = material_id
         self.dirty_material = True
+        self.transparent: bool = False
         # will be set when inserted in the render context
         self.geom_id = None
 
@@ -247,6 +248,7 @@ class TT2DPoints(WithMaterialID, TT2DNode):
             0,
             self.node_id,
             self.material_id,
+            self.transparent,
         )
 
 
@@ -270,6 +272,7 @@ class TT2DLines(TT2DNode):
             ]
         )
         self.material_id = material_id
+        self.transparent: bool = False
 
         # will be set when inserted in the render context
         self.geom_id = None
@@ -296,6 +299,7 @@ class TT2DLines(TT2DNode):
             self.segment_idx[0],
             self.node_id,
             self.material_id,
+            self.transparent,
         )
 
 
@@ -365,6 +369,7 @@ class TT2DPolygon(WithMaterialID, TT2DNode):
             triangle_count,
             self.node_id,
             self.material_id,
+            self.transparent,
         )
 
 
@@ -409,6 +414,7 @@ class TT2DRect(TT2DNode):
         self.width = width
         self.height = height
         self.material_id = material_id
+        self.transparent: bool = False
 
         # will be set when inserted in the render context
         self.geom_id = None
@@ -432,4 +438,5 @@ class TT2DRect(TT2DNode):
             uv_start_index,
             self.node_id,
             self.material_id,
+            self.transparent,
         )

--- a/python/tt3de/tt_3dnodes.py
+++ b/python/tt3de/tt_3dnodes.py
@@ -101,6 +101,7 @@ class TT3DPolygonFan(WithMaterialID, TT3DNode):
         self.vertex_list: List[Point3D] = []
         self.uvmap: List[tuple[Point2D, Point2D, Point2D]] = []
         self.geom_id = None
+        self.transparent: bool = False
 
     def insert_in(self, rc: "RustRenderContext"):
         super().insert_in(rc)
@@ -127,6 +128,7 @@ class TT3DPolygonFan(WithMaterialID, TT3DNode):
             self.node_id,
             self.material_id,
             start_uv,
+            self.transparent,
         )
 
 
@@ -143,6 +145,7 @@ class TT3DPolygon(WithMaterialID, TT3DNode):
         self.uvmap: List[tuple[Point2D, Point2D, Point2D]] = []
         self.geom_id = None
         self.flipped_normals: bool = False
+        self.transparent: bool = False
 
     def insert_in(self, rc: "RustRenderContext"):
         super().insert_in(rc)
@@ -197,6 +200,7 @@ class TT3DPolygon(WithMaterialID, TT3DNode):
             triangle_count,
             self.node_id,
             self.material_id,
+            self.transparent,
         )
 
 
@@ -211,6 +215,7 @@ class TT3DPoint(WithMaterialID, TT3DNode):
         self.vertex_list: List[Point3D] = []
         self.uvmap: List[tuple[Point2D, Point2D, Point2D]] = []
         self.geom_id = None
+        self.transparent: bool = False
 
     def insert_in(self, rc: "RustRenderContext"):
         super().insert_in(rc)
@@ -232,7 +237,7 @@ class TT3DPoint(WithMaterialID, TT3DNode):
         assert start_idx is not None
         assert start_uv is not None
         self.geom_id = rc.geometry_buffer.add_point_3d(
-            start_idx, start_uv, self.node_id, self.material_id
+            start_idx, start_uv, self.node_id, self.material_id, self.transparent
         )
 
 
@@ -247,6 +252,7 @@ class TT3DLine(WithMaterialID, TT3DNode):
         self.vertex_list: List[Point3D] = []
         self.segment_uv: List[Tuple[Point2D, Point2D]] = []
         self.geom_id = None
+        self.transparent: bool = False
 
     def insert_in(self, rc: "RustRenderContext"):
         super().insert_in(rc)
@@ -267,4 +273,5 @@ class TT3DLine(WithMaterialID, TT3DNode):
             self.segment_idx[0],
             self.node_id,
             self.material_id,
+            self.transparent,
         )

--- a/python/tt3de/ttsl/compiler.py
+++ b/python/tt3de/ttsl/compiler.py
@@ -169,17 +169,21 @@ class TTSLCompilerContext:
 
     @classmethod
     def always_present_variables(cls) -> Dict[str, IRType]:
-        """Per-cell inputs only (including ``tt_FrontFacing`` as ``bool``, winding-based,
+        """
+        Per-cell inputs only (including ``tt_FrontFacing`` as ``bool``, winding-based,
         ``tt_FragDepth`` as ``float`` (depth value for the shaded depth layer from the
-        depth buffer), ``tt_LineCoord`` as ``float`` (parametric coordinate along rasterized
-        line segments, ``0.0`` when not a line), ``tt_PointCoord`` as ``glm.vec2`` (coordinates
-        within a point sprite, ``(0, 0)`` when not a point), and ``tt_PrimitiveID`` as ``int``: per-pixel
-        index of the depth-winning primitive,
-        ``[0..PrimitiveBuffer.current_size-1]``; mirrors GLSL ``gl_PrimitiveID``).
+        depth buffer), ``tt_LineCoord`` as ``float`` (parametric coordinate along
+        rasterized line segments, ``0.0`` when not a line), ``tt_PointCoord`` as
+        ``glm.vec2`` (coordinates within a point sprite, ``(0, 0)`` when not a point),
+        and ``tt_PrimitiveID`` as ``int``: per-pixel index of the depth-winning
+        primitive, ``[0..PrimitiveBuffer.current_size-1]``; mirrors GLSL
+        ``gl_PrimitiveID``).
+
         Engine uniforms such as ``tt_Time`` / ``tt_DeltaTime`` (``float``), ``tt_Frame``
         (``int``), ``tt_Resolution`` (``glm.vec2``: width_cells, height_cells), and
         ``tt_Near`` / ``tt_Far`` (``float``: clip distances) must be
-        passed via ``globals_dict`` when referenced."""
+        passed via ``globals_dict`` when referenced.
+        """
         return dict(PIXEL_VARIABLES_STR_TYPE)
 
     def comment(self, text: str):
@@ -237,6 +241,23 @@ class TTSLCompilerContext:
             comment=comment,
         )
         return self.code.append(instr)
+
+    def emit_label(self) -> int:
+        label = f"S_{self.code.label_counter}"
+        self.code.label_counter += 1
+        return self.code.append(
+            IRInstr(
+                op=OpCodes.LABEL,
+                dst=None,
+                src1=None,
+                src2=None,
+                src3=None,
+                src4=None,
+                imm=None,
+                label=label,
+                comment=" ",
+            )
+        )
 
     def alloc_temp_for_type(self, ty: IRType) -> Temp:
         reg = Temp(id=self.next_temp_id, ty=ty)
@@ -448,7 +469,15 @@ class TTSLCompilerContext:
             func = node.func
             args = node.args
             if "id" in func._fields:
-                if func.id in ("sin", "abs", "cos", "floor", "ceil", "fract", "normalize"):
+                if func.id in (
+                    "sin",
+                    "abs",
+                    "cos",
+                    "floor",
+                    "ceil",
+                    "fract",
+                    "normalize",
+                ):
                     assert len(args) == 1
                     return_type = self.type_of(args[0])
                     arg_reg = self.compile_expr(args[0], return_type)
@@ -473,8 +502,13 @@ class TTSLCompilerContext:
                     x_reg = self.compile_expr(args[0], x_ty)
                     y_reg = self.compile_expr(args[1], y_ty)
                     result_reg = self.alloc_temp_for_type(x_ty)
-                    self.emit_2(OpCodes.MOD, x_reg, y_reg, result_reg,
-                                comment=f"mod r{x_reg.id}, r{y_reg.id} -> r{result_reg.id}")
+                    self.emit_2(
+                        OpCodes.MOD,
+                        x_reg,
+                        y_reg,
+                        result_reg,
+                        comment=f"mod r{x_reg.id}, r{y_reg.id} -> r{result_reg.id}",
+                    )
                     return result_reg
                 elif func.id == "dot":
                     if len(args) != 2:
@@ -497,8 +531,13 @@ class TTSLCompilerContext:
                     a_reg = self.compile_expr(args[0], a_ty)
                     b_reg = self.compile_expr(args[1], b_ty)
                     result_reg = self.alloc_temp_for_type(IRType.F32)
-                    self.emit_2(OpCodes.DOT, a_reg, b_reg, result_reg,
-                                comment=f"dot r{a_reg.id}, r{b_reg.id} -> r{result_reg.id} (f32)")
+                    self.emit_2(
+                        OpCodes.DOT,
+                        a_reg,
+                        b_reg,
+                        result_reg,
+                        comment=f"dot r{a_reg.id}, r{b_reg.id} -> r{result_reg.id} (f32)",
+                    )
                     return result_reg
                 elif func.id in VECTOR_CONSTRUCTORS:
                     return self.compile_vec_constructor(
@@ -518,8 +557,12 @@ class TTSLCompilerContext:
                         )
                     v_reg = self.compile_expr(args[0], v_ty)
                     result_reg = self.alloc_temp_for_type(IRType.F32)
-                    self.emit_1(OpCodes.LENGTH, v_reg, result_reg,
-                                comment=f"length r{v_reg.id} -> r{result_reg.id} (f32)")
+                    self.emit_1(
+                        OpCodes.LENGTH,
+                        v_reg,
+                        result_reg,
+                        comment=f"length r{v_reg.id} -> r{result_reg.id} (f32)",
+                    )
                     return result_reg
                 elif func.id == "max":
                     if len(args) != 2:
@@ -542,8 +585,13 @@ class TTSLCompilerContext:
                     a_reg = self.compile_expr(args[0], a_ty)
                     b_reg = self.compile_expr(args[1], b_ty)
                     result_reg = self.alloc_temp_for_type(a_ty)
-                    self.emit_2(OpCodes.MAX, a_reg, b_reg, result_reg,
-                                comment=f"max r{a_reg.id}, r{b_reg.id} -> r{result_reg.id}")
+                    self.emit_2(
+                        OpCodes.MAX,
+                        a_reg,
+                        b_reg,
+                        result_reg,
+                        comment=f"max r{a_reg.id}, r{b_reg.id} -> r{result_reg.id}",
+                    )
                     return result_reg
                 elif func.id == "clamp":
                     if len(args) != 3:
@@ -570,7 +618,10 @@ class TTSLCompilerContext:
                     result_reg = self.alloc_temp_for_type(x_ty)
                     self.emit(
                         OpCodes.CLAMP,
-                        x_reg, lo_reg, hi_reg, None,
+                        x_reg,
+                        lo_reg,
+                        hi_reg,
+                        None,
                         result_reg,
                         comment=f"clamp r{x_reg.id}, r{lo_reg.id}, r{hi_reg.id} -> r{result_reg.id}",
                     )
@@ -634,8 +685,12 @@ class TTSLCompilerContext:
                                 )
                             v_reg = self.compile_expr(args[0], v_ty)
                             result_reg = self.alloc_temp_for_type(IRType.F32)
-                            self.emit_1(OpCodes.LENGTH, v_reg, result_reg,
-                                        comment=f"glm.length r{v_reg.id} -> r{result_reg.id} (f32)")
+                            self.emit_1(
+                                OpCodes.LENGTH,
+                                v_reg,
+                                result_reg,
+                                comment=f"glm.length r{v_reg.id} -> r{result_reg.id} (f32)",
+                            )
                             return result_reg
                         elif func_name == "max":
                             if len(args) != 2:
@@ -653,8 +708,13 @@ class TTSLCompilerContext:
                             a_reg = self.compile_expr(args[0], a_ty)
                             b_reg = self.compile_expr(args[1], b_ty)
                             result_reg = self.alloc_temp_for_type(a_ty)
-                            self.emit_2(OpCodes.MAX, a_reg, b_reg, result_reg,
-                                        comment=f"glm.max r{a_reg.id}, r{b_reg.id} -> r{result_reg.id}")
+                            self.emit_2(
+                                OpCodes.MAX,
+                                a_reg,
+                                b_reg,
+                                result_reg,
+                                comment=f"glm.max r{a_reg.id}, r{b_reg.id} -> r{result_reg.id}",
+                            )
                             return result_reg
                         elif func_name == "clamp":
                             if len(args) != 3:
@@ -676,7 +736,10 @@ class TTSLCompilerContext:
                             result_reg = self.alloc_temp_for_type(x_ty)
                             self.emit(
                                 OpCodes.CLAMP,
-                                x_reg, lo_reg, hi_reg, None,
+                                x_reg,
+                                lo_reg,
+                                hi_reg,
+                                None,
                                 result_reg,
                                 comment=f"glm.clamp r{x_reg.id}, r{lo_reg.id}, r{hi_reg.id} -> r{result_reg.id}",
                             )
@@ -710,8 +773,13 @@ class TTSLCompilerContext:
                             x_reg = self.compile_expr(args[0], x_ty)
                             y_reg = self.compile_expr(args[1], y_ty)
                             result_reg = self.alloc_temp_for_type(x_ty)
-                            self.emit_2(OpCodes.MOD, x_reg, y_reg, result_reg,
-                                        comment=f"glm.mod r{x_reg.id}, r{y_reg.id} -> r{result_reg.id}")
+                            self.emit_2(
+                                OpCodes.MOD,
+                                x_reg,
+                                y_reg,
+                                result_reg,
+                                comment=f"glm.mod r{x_reg.id}, r{y_reg.id} -> r{result_reg.id}",
+                            )
                             return result_reg
                         elif func_name == "dot":
                             if len(args) != 2:
@@ -734,8 +802,13 @@ class TTSLCompilerContext:
                             a_reg = self.compile_expr(args[0], a_ty)
                             b_reg = self.compile_expr(args[1], b_ty)
                             result_reg = self.alloc_temp_for_type(IRType.F32)
-                            self.emit_2(OpCodes.DOT, a_reg, b_reg, result_reg,
-                                        comment=f"glm.dot r{a_reg.id}, r{b_reg.id} -> r{result_reg.id} (f32)")
+                            self.emit_2(
+                                OpCodes.DOT,
+                                a_reg,
+                                b_reg,
+                                result_reg,
+                                comment=f"glm.dot r{a_reg.id}, r{b_reg.id} -> r{result_reg.id} (f32)",
+                            )
                             return result_reg
                         elif func_name in GLM_TOOLS:
                             return self.compile_glm_tool_call(node, func_name, args)
@@ -896,6 +969,108 @@ class TTSLCompilerContext:
         )
 
     def compile_if(self, node: ast.If):
+        # Special-case boolean short-circuit in conditions. We model control flow
+        # directly (jumps) instead of materializing bool expressions into registers.
+        if isinstance(node.test, ast.BoolOp):
+            values = node.test.values
+            if len(values) < 2:
+                raise CompileError(
+                    node.test, "Boolean operation requires at least 2 operands"
+                )
+            for value in values:
+                value_type = self.type_of(value)
+                if value_type != IRType.BOOL:
+                    raise CompileError(
+                        value,
+                        f"If boolean condition operands must be bool, got {value_type}",
+                    )
+
+            if isinstance(node.test.op, ast.And):
+                jmp_false_positions: list[int] = []
+                for idx, value in enumerate(values):
+                    cond_reg = self.compile_expr(value, IRType.BOOL)
+                    jmp_false_positions.append(
+                        self.emit_2(
+                            OpCodes.JMP_IF_FALSE,
+                            cond_reg,
+                            None,
+                            None,
+                            comment=f"if-and short-circuit false on r{cond_reg.id}",
+                        )
+                    )
+                    if idx < len(values) - 1:
+                        self.emit_label()
+
+                self.compile_block(node.body)
+                jmp_end_pos: Optional[int] = None
+                if self._last_meaningful_ir_op() != OpCodes.RET:
+                    jmp_end_pos = self.emit_2(OpCodes.JMP, None, None, None)
+
+                else_start = self.code.instructions_count()
+                self.compile_block(node.orelse)
+
+                for jmp_false_pos in jmp_false_positions:
+                    self.code.patch_target(jmp_false_pos, else_start)
+                if jmp_end_pos is not None:
+                    end_pos = self.code.instructions_count()
+                    self.code.patch_target(jmp_end_pos, end_pos)
+                return
+
+            if isinstance(node.test.op, ast.Or):
+                jmp_true_to_then_positions: list[int] = []
+                for value in values[:-1]:
+                    cond_reg = self.compile_expr(value, IRType.BOOL)
+                    jmp_next_pos = self.emit_2(
+                        OpCodes.JMP_IF_FALSE,
+                        cond_reg,
+                        None,
+                        None,
+                        comment=f"if-or evaluate next on false r{cond_reg.id}",
+                    )
+                    self.emit_label()
+                    jmp_true_to_then_positions.append(
+                        self.emit_2(
+                            OpCodes.JMP,
+                            None,
+                            None,
+                            None,
+                            comment="if-or short-circuit true",
+                        )
+                    )
+                    self.emit_label()
+                    next_pos = self.code.instructions_count()
+                    self.code.patch_target(jmp_next_pos, next_pos)
+
+                last_reg = self.compile_expr(values[-1], IRType.BOOL)
+                jmp_false_pos = self.emit_2(
+                    OpCodes.JMP_IF_FALSE,
+                    last_reg,
+                    None,
+                    None,
+                    comment=f"if-or last operand false on r{last_reg.id}",
+                )
+
+                then_start = self.code.instructions_count()
+                self.compile_block(node.body)
+                for jmp_true_pos in jmp_true_to_then_positions:
+                    self.code.patch_target(jmp_true_pos, then_start)
+
+                jmp_end_pos: Optional[int] = None
+                if self._last_meaningful_ir_op() != OpCodes.RET:
+                    jmp_end_pos = self.emit_2(OpCodes.JMP, None, None, None)
+
+                else_start = self.code.instructions_count()
+                self.compile_block(node.orelse)
+                self.code.patch_target(jmp_false_pos, else_start)
+                if jmp_end_pos is not None:
+                    end_pos = self.code.instructions_count()
+                    self.code.patch_target(jmp_end_pos, end_pos)
+                return
+
+            raise CompileError(
+                node.test, f"Unsupported boolean operator {type(node.test.op).__name__}"
+            )
+
         # 1. condition
         test_type = self.type_of(node.test)
         if test_type != IRType.BOOL:
@@ -1005,7 +1180,15 @@ class TTSLCompilerContext:
             if "id" in node._fields:
                 if node.id in self.named_variables:
                     return self.named_variables[node.id].ty
-                elif node.id in ("abs", "sin", "cos", "floor", "ceil", "fract", "normalize"):
+                elif node.id in (
+                    "abs",
+                    "sin",
+                    "cos",
+                    "floor",
+                    "ceil",
+                    "fract",
+                    "normalize",
+                ):
                     if type_args is not None and len(type_args) == 1:
                         return type_args[0]
                     raise CompileError(
@@ -1216,6 +1399,22 @@ class TTSLCompilerContext:
             return func_type
         elif isinstance(node, ast.Compare):
             return IRType.BOOL
+        elif isinstance(node, ast.BoolOp):
+            if len(node.values) < 2:
+                raise CompileError(
+                    node,
+                    "Boolean operation requires at least 2 operands",
+                )
+            for value in node.values:
+                value_type = self.type_of(value)
+                if value_type != IRType.BOOL:
+                    raise CompileError(
+                        value,
+                        f"Boolean operation operands must be bool, got {value_type}",
+                    )
+            if isinstance(node.op, (ast.And, ast.Or)):
+                return IRType.BOOL
+            raise NotImplementedError(f"Unsupported boolean operator: {node.op}")
         # elif isinstance(node, ast.Return):
         elif isinstance(node, ast.UnaryOp):
             operand_type = self.type_of(node.operand)
@@ -1255,7 +1454,9 @@ def compile_ttsl_function(
     return sc
 
 
-def parse_ttsl_source(src: str, function_name: str) -> Tuple[ast.Module, ast.FunctionDef]:
+def parse_ttsl_source(
+    src: str, function_name: str
+) -> Tuple[ast.Module, ast.FunctionDef]:
     tree = ast.parse(src)
     fn_node: Optional[ast.FunctionDef] = None
     for node in tree.body:
@@ -1276,7 +1477,8 @@ def type_of_annotation(arg_annotation) -> IRType:
 
 
 def _validate_shader_returns_annotation(fn_node: ast.FunctionDef) -> None:
-    """If the shader function has a return annotation, require tuple[vec4, vec4, int]."""
+    """If the shader function has a return annotation, require tuple[vec4, vec4,
+    int]."""
     ann = fn_node.returns
     if ann is None:
         return
@@ -1530,10 +1732,11 @@ class SSARenamer:
             for var, phi in succ_node.phis.items():
                 cur = self.top(var)
                 if cur is None:
-                    raise ValueError(
-                        f"SSA rename: no current version for var {var!r} "
-                        f"when filling phi operand from pred {block_idx} -> {succ_idx}"
-                    )
+                    # Cytron insertion here is unpruned (no liveness filtering), so a
+                    # successor can carry dead phi(var) where `var` is not defined
+                    # on all incoming edges. Skip the missing edge operand; phi
+                    # lowering only emits copies for present operands.
+                    continue
                 assert isinstance(phi.phi_operands, Dict)
                 phi.phi_operands[block_idx] = cur
 
@@ -1953,9 +2156,9 @@ class RegisterAllocatorPass(CompilationPass):
                 # Pin to ``regs.i32_[0]`` so ``ShaderInputBinding::primitive_id_i32_reg`` (default
                 # ``0``) and ``ShaderMaterial::render_mat`` write ``PixInfo::primitive_id`` into the
                 # exact register the bytecode reads from.
-                assert temp.ty == IRType.I32, (
-                    "tt_PrimitiveID must be IRType.I32 (declared in PIXEL_VARIABLES_STR_TYPE)"
-                )
+                assert (
+                    temp.ty == IRType.I32
+                ), "tt_PrimitiveID must be IRType.I32 (declared in PIXEL_VARIABLES_STR_TYPE)"
                 idx = 0
                 allocated_registers.setdefault(IRType.I32, set()).add(0)
             else:
@@ -2423,7 +2626,8 @@ class RegisterSettings:
         return regs
 
     def fork(self) -> "RegisterSettings":
-        """Copy allocation maps so per-material ``set_variable`` calls do not alias state.
+        """
+        Copy allocation maps so per-material ``set_variable`` calls do not alias state.
 
         Used when one compiled bytecode is shared across multiple ``ShaderPy`` instances
         with different register seeds (for example per-instance ``u_albedo``).
@@ -2435,7 +2639,9 @@ class RegisterSettings:
 
 
 def shader_py_frag_depth_clip_kwargs(reg_settings: RegisterSettings) -> Dict[str, int]:
-    """Keyword arguments for ``ShaderPy`` when the shader uses ``tt_FragDepth``, ``tt_Near``, and ``tt_Far``.
+    """
+    Keyword arguments for ``ShaderPy`` when the shader uses ``tt_FragDepth``,
+    ``tt_Near``, and ``tt_Far``.
 
     Call after ``all_passes_compilation`` with a ``globals_dict`` that includes
     ``GLOBAL_VAR_TT_NEAR`` and ``GLOBAL_VAR_TT_FAR`` so clip uniforms are allocated.
@@ -2451,7 +2657,9 @@ def shader_py_frag_depth_clip_kwargs(reg_settings: RegisterSettings) -> Dict[str
         (GLOBAL_VAR_TT_NEAR, "near_f32_reg"),
         (GLOBAL_VAR_TT_FAR, "far_f32_reg"),
     ]
-    missing = [name for name, _ in bindings if name not in reg_settings.var_name_to_registers]
+    missing = [
+        name for name, _ in bindings if name not in reg_settings.var_name_to_registers
+    ]
     if missing:
         raise ValueError(
             "Register allocation is missing depth/clip bindings for shader_py_frag_depth_clip_kwargs: "
@@ -2465,7 +2673,8 @@ def shader_py_frag_depth_clip_kwargs(reg_settings: RegisterSettings) -> Dict[str
 
 
 def apply_engine_uniform_register_defaults(reg_settings: RegisterSettings) -> None:
-    """Seed registers for globals / always-present builtins that have a documented default.
+    """
+    Seed registers for globals / always-present builtins that have a documented default.
 
     ``tt_Frame`` defaults to ``0`` until the host writes a frame counter. ``tt_Resolution``
     defaults to ``(1, 1)`` cells when the host has not written a size yet; components ``<= 0``
@@ -2600,8 +2809,13 @@ def all_passes_compilation_with_state(
         final_byte_code = PassToByteCode(cc).run(result.register_allocation)
         result.final_byte_code = final_byte_code
 
-        reg_settings = RegisterSettings(result.register_allocation.var_names_to_registers)
-        for (ty, reg_id), value in result.register_allocation.const_id_to_registers.values():
+        reg_settings = RegisterSettings(
+            result.register_allocation.var_names_to_registers
+        )
+        for (
+            ty,
+            reg_id,
+        ), value in result.register_allocation.const_id_to_registers.values():
             reg_settings.set_register(ty, reg_id, value)
         apply_engine_uniform_register_defaults(reg_settings)
         result.register_settings = reg_settings

--- a/source/high_level_api.rst
+++ b/source/high_level_api.rst
@@ -49,6 +49,9 @@ Most demos start by loading a default texture/material set:
 
 Then assign ``material_id`` on each node/mesh.
 
+For transparency layers, see ``source/low_level_api.rst`` (two-pass model,
+``legacy_layers`` migration path, and blend semantics).
+
 
 Custom materials
 ^^^^^^^^^^^^^^^^
@@ -73,8 +76,13 @@ You can create material entries dynamically via ``material_buffer``:
             front_uv_0=True,
             back_uv_0=False,
             glyph_method=...,
+            blend_mode="alpha_blend",
+            glyph_policy="preserve_existing",
         )
     )
+
+To route geometry to the transparent pass, set ``node.transparent = True`` on
+``TT2D*`` / ``TT3D*`` primitives before inserting them in the render context.
 
 
 TTSL ``ShaderPy`` materials

--- a/source/high_level_api.rst
+++ b/source/high_level_api.rst
@@ -49,8 +49,8 @@ Most demos start by loading a default texture/material set:
 
 Then assign ``material_id`` on each node/mesh.
 
-For transparency layers, see ``source/low_level_api.rst`` (two-pass model,
-``legacy_layers`` migration path, and blend semantics).
+For transparency layers, see ``source/low_level_api.rst`` (canonical two-pass
+model and blend semantics).
 
 
 Custom materials

--- a/source/low_level_api.rst
+++ b/source/low_level_api.rst
@@ -107,43 +107,27 @@ Depth Buffer:
 Depth layer resolve
 ^^^^^^^^^^^^^^^^^^^
 
-The drawing buffer is not a single OpenGL-style depth sample per terminal
-cell. It stores a small fixed stack of depth layers per cell (currently two
-layers through ``DrawingBufferPy`` / ``DrawBuffer<2, f32>``). Each layer keeps
-both a depth value and a reference to the matching ``PixInfo`` entry for that
-fragment: UVs, normal, material id, primitive id, and other per-pixel data.
+``DrawingBufferPy`` now supports two rendering models:
 
-During rasterization, ``DrawBuffer::set_depth_content`` inserts each covered
-fragment into the cell's depth stack if it is closer than an existing layer.
-The stack is kept sorted nearest-first: layer ``0`` is the closest stored
-fragment, layer ``1`` is the next closest fragment, and any fragment beyond the
-available layer count is dropped.
+- ``legacy_layers=True`` (default): legacy ``DrawBuffer<2, f32>`` K-buffer-like
+  resolve behavior for compatibility.
+- ``legacy_layers=False``: two-pass model with one depth winner per pass.
 
-After rasterization, ``apply_material_on`` resolves each cell by shading layers
-from farthest to nearest:
+New two-pass behavior (``legacy_layers=False``):
 
-.. code-block:: rust
+1. **Opaque pass** rasterizes non-transparent primitives into ``DrawBuffer<1, f32>``.
+2. **Opaque material resolve** writes full ``CanvasCell`` state (front/back/glyph).
+3. **Transparent pass** rasterizes transparent primitives into another
+   ``DrawBuffer<1, f32>``.
+4. **Transparent composite** blends only ``front_color`` onto the opaque canvas.
 
-    for depth_layer in (0..DEPTHLAYER).rev() {
-        // shade this layer into the same CanvasCell
-    }
+Blend/composite is centralized through ``BlendMode`` (``replace``,
+``alpha_blend``, ``additive``, ``glyph_dither``, ``half_block_composite``),
+while glyph behavior in transparent compositing is explicit through
+``GlyphPolicy`` (``preserve_existing`` / ``replace_from_shader``).
 
-All layers write into the same final ``CanvasCell`` fields: ``front_color``,
-``back_color``, and ``glyph``. There is no single global blend equation at this
-stage. The effective compositing behavior is material-defined:
-
-- ``StaticColor`` copies only the channels enabled by its ``front``, ``back``,
-  and ``glyph`` toggles.
-- ``BaseTexture`` can alpha-blend front/back colors and can choose a glyph from
-  texture data or a fixed glyph method.
-- ``Textured`` and many shader paths overwrite the channels they produce.
-- Glyph composition is usually last-writer-wins for whichever nearer material
-  writes a glyph.
-
-This makes tt3de closer to a tiny fixed-size **K-buffer** / order-independent
-transparency approach than to the classic OpenGL default framebuffer model. The
-engine stores a few visible fragments first, then resolves them into one ASCII
-cell.
+Depth ordering of overlapping transparent primitives remains raster-order
+dependent in this milestone (no transparent sort yet).
 
 For comparison, classic OpenGL normally has one depth value per pixel. A
 fragment passes or fails the depth test against that single value; if it passes,

--- a/source/low_level_api.rst
+++ b/source/low_level_api.rst
@@ -107,13 +107,7 @@ Depth Buffer:
 Depth layer resolve
 ^^^^^^^^^^^^^^^^^^^
 
-``DrawingBufferPy`` now supports two rendering models:
-
-- ``legacy_layers=True`` (default): legacy ``DrawBuffer<2, f32>`` K-buffer-like
-  resolve behavior for compatibility.
-- ``legacy_layers=False``: two-pass model with one depth winner per pass.
-
-New two-pass behavior (``legacy_layers=False``):
+``DrawingBufferPy`` uses one canonical two-pass model with one depth winner per pass:
 
 1. **Opaque pass** rasterizes non-transparent primitives into ``DrawBuffer<1, f32>``.
 2. **Opaque material resolve** writes full ``CanvasCell`` state (front/back/glyph).
@@ -136,6 +130,13 @@ Transparent rendering is usually handled separately by drawing opaque geometry
 first, then drawing transparent geometry back-to-front with blending enabled
 and depth writes disabled, or by using advanced techniques such as depth
 peeling, A-buffers, or K-buffers.
+
+Migration note
+^^^^^^^^^^^^^^
+
+The ``legacy_layers`` constructor kwarg was removed from ``DrawingBufferPy``.
+Update existing code by deleting that kwarg and validating scenes that relied
+on legacy two-layer stacking artifacts.
 
 
 Material modes

--- a/source/ttsl.md
+++ b/source/ttsl.md
@@ -148,6 +148,57 @@ material mode is `Shader`, the material owns compiled TTSL bytecode and executes
 it during material application so shader output directly drives final cell
 channels (`front_color`, `back_color`, `glyph`).
 
+### Transparency in TTSL shaders
+
+Shader materials write final terminal cell channels directly. There is no extra
+alpha compositing pass after your shader returns `(front, back, glyph)`.
+Because of that, transparent texels must be handled in shader code by masking
+their output color (for example, returning black background color).
+
+#### 1) Single raster path (one UV, no double raster)
+
+Use one sampled texel and apply one alpha test. If transparent, zero both
+returned colors.
+
+```python
+def sprite_single(tt_TexCoord0: vec2) -> tuple[vec4, vec4, int]:
+    sampled: vec4 = tt_texture(u_TextureIndex, tt_TexCoord0)
+    if sampled.w < 0.5:
+        return (vec4(0.0, 0.0, 0.0, 1.0), vec4(0.0, 0.0, 0.0, 1.0), 0)
+    rgb: vec4 = vec4(sampled.x, sampled.y, sampled.z, 1.0)
+    return (rgb, rgb, 0)
+```
+
+This is the safest default for normal sprite quads where one sample drives both
+foreground/background halves of the terminal cell.
+
+#### 2) Double raster path (two UVs, like the bouncing clock demo)
+
+When top and bottom halves come from different UV interpolations (`tt_TexCoord0`
+and `tt_TexCoord1`), mask each half independently. Do not only test the combined
+condition, or key-color fringes can appear at transparent boundaries.
+
+```python
+def clock_tex(tt_TexCoord0: vec2, tt_TexCoord1: vec2) -> tuple[vec4, vec4, int]:
+    sampled_top: vec4 = tt_texture(u_TextureIndex, tt_TexCoord0)
+    sampled_bottom: vec4 = tt_texture(u_TextureIndex, tt_TexCoord1)
+    # Shader materials write final colors directly (no alpha compositing pass), so
+    # each half-cell must black out its own transparent texels to avoid key-color
+    # fringes from the sprite sheet at glyph boundaries.
+    if sampled_top.w < 0.5:
+        top_rgb: vec4 = vec4(0.0, 0.0, 0.0, 1.0)
+    else:
+        top_rgb: vec4 = vec4(sampled_top.x, sampled_top.y, sampled_top.z, 1.0)
+    if sampled_bottom.w < 0.5:
+        bottom_rgb: vec4 = vec4(0.0, 0.0, 0.0, 1.0)
+    else:
+        bottom_rgb: vec4 = vec4(sampled_bottom.x, sampled_bottom.y, sampled_bottom.z, 1.0)
+    return (top_rgb, bottom_rgb, 0)
+```
+
+This is the recommended pattern whenever your material uses two raster samples
+per terminal cell.
+
 ### TTSL Python compiler surface syntax
 
 The TTSL compiler requires the shader to ``return`` a 3-tuple ``(front, back, glyph)``

--- a/src/drawbuffer/blend.rs
+++ b/src/drawbuffer/blend.rs
@@ -1,0 +1,130 @@
+use nalgebra_glm::Vec4;
+
+use super::drawbuffer::Color;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum BlendMode {
+    Replace,
+    AlphaBlend,
+    Additive,
+    GlyphDither,
+    HalfBlockComposite,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum GlyphPolicy {
+    PreserveExisting,
+    ReplaceFromShader,
+}
+
+impl Default for BlendMode {
+    fn default() -> Self {
+        Self::Replace
+    }
+}
+
+impl Default for GlyphPolicy {
+    fn default() -> Self {
+        Self::PreserveExisting
+    }
+}
+
+#[inline]
+fn clamp_u8_from_unit(v: f32) -> u8 {
+    (v.clamp(0.0, 1.0) * 255.0).round() as u8
+}
+
+#[inline]
+fn src_rgb(src: &Vec4) -> (f32, f32, f32) {
+    (
+        src.x.clamp(0.0, 1.0),
+        src.y.clamp(0.0, 1.0),
+        src.z.clamp(0.0, 1.0),
+    )
+}
+
+#[inline]
+fn dst_rgb(dst: &Color) -> (f32, f32, f32) {
+    (
+        dst.r as f32 / 255.0,
+        dst.g as f32 / 255.0,
+        dst.b as f32 / 255.0,
+    )
+}
+
+pub fn blend_front(dst: &Color, src: &Vec4, mode: BlendMode) -> Color {
+    let (sr, sg, sb) = src_rgb(src);
+    let (dr, dg, db) = dst_rgb(dst);
+    let sa = src.w.clamp(0.0, 1.0);
+
+    let (r, g, b) = match mode {
+        BlendMode::Replace => (sr, sg, sb),
+        BlendMode::AlphaBlend => (
+            sr * sa + dr * (1.0 - sa),
+            sg * sa + dg * (1.0 - sa),
+            sb * sa + db * (1.0 - sa),
+        ),
+        BlendMode::Additive => (dr + sr, dg + sg, db + sb),
+        // TODO(evol-transparency-depth-layers): add dedicated ASCII-native math.
+        // For now these are deterministic conservative fallbacks.
+        BlendMode::GlyphDither => (
+            sr * sa + dr * (1.0 - sa),
+            sg * sa + dg * (1.0 - sa),
+            sb * sa + db * (1.0 - sa),
+        ),
+        BlendMode::HalfBlockComposite => (
+            sr * sa + dr * (1.0 - sa),
+            sg * sa + dg * (1.0 - sa),
+            sb * sa + db * (1.0 - sa),
+        ),
+    };
+
+    Color::new(
+        clamp_u8_from_unit(r),
+        clamp_u8_from_unit(g),
+        clamp_u8_from_unit(b),
+        255,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use nalgebra_glm::vec4;
+
+    use super::*;
+
+    #[test]
+    fn blend_replace_overwrites() {
+        let dst = Color::new(255, 0, 0, 255);
+        let out = blend_front(&dst, &vec4(0.0, 1.0, 0.0, 1.0), BlendMode::Replace);
+        assert_eq!(out, Color::new(0, 255, 0, 255));
+    }
+
+    #[test]
+    fn blend_alpha_blend_half_mix() {
+        let dst = Color::new(255, 0, 0, 255);
+        let out = blend_front(&dst, &vec4(0.0, 1.0, 0.0, 0.5), BlendMode::AlphaBlend);
+        assert_eq!(out, Color::new(128, 128, 0, 255));
+    }
+
+    #[test]
+    fn blend_alpha_zero_keeps_dst() {
+        let dst = Color::new(255, 255, 255, 255);
+        let out = blend_front(&dst, &vec4(0.0, 0.0, 0.0, 0.0), BlendMode::AlphaBlend);
+        assert_eq!(out, Color::new(255, 255, 255, 255));
+    }
+
+    #[test]
+    fn blend_additive_clamps() {
+        let dst = Color::new(128, 0, 0, 255);
+        let out = blend_front(&dst, &vec4(0.0, 0.0, 1.0, 1.0), BlendMode::Additive);
+        assert_eq!(out, Color::new(128, 0, 255, 255));
+    }
+
+    #[test]
+    fn blend_clamps_input_channels() {
+        let dst = Color::new(255, 255, 255, 255);
+        let out = blend_front(&dst, &vec4(2.0, -1.0, 0.5, 2.0), BlendMode::AlphaBlend);
+        assert_eq!(out, Color::new(255, 0, 128, 255));
+    }
+}

--- a/src/drawbuffer/drawbuffer.rs
+++ b/src/drawbuffer/drawbuffer.rs
@@ -17,6 +17,7 @@ use crate::material::MaterialBuffer;
 use crate::primitivbuffer::primitivbuffer::PrimitiveBuffer;
 use crate::texturebuffer::RGBA;
 use crate::vertexbuffer::uv_buffer::UVBuffer;
+use super::blend::{blend_front, GlyphPolicy};
 
 /// Twice the signed area of triangle `(a,b,c)` in the plane with **X = column**, **Y = row**
 /// (same axes as vertex `pos.x` / `pos.y` during rasterization).
@@ -780,4 +781,55 @@ pub fn apply_material_on_parallel<const TEXTURESIZE: usize, const DEPTHLAYER: us
                 }
             });
     });
+}
+
+fn color_to_vec4(color: &Color) -> Vec4 {
+    Vec4::new(
+        color.r as f32 / 255.0,
+        color.g as f32 / 255.0,
+        color.b as f32 / 255.0,
+        color.a as f32 / 255.0,
+    )
+}
+
+pub fn apply_material_transparent_on<const TEXTURESIZE: usize, const DEPTHLAYER: usize>(
+    transparent_buffer: &DrawBuffer<DEPTHLAYER, f32>,
+    opaque_buffer: &mut DrawBuffer<1, f32>,
+    material_buffer: &MaterialBuffer,
+    texture_buffer: &TextureBuffer<TEXTURESIZE>,
+    uv_buffer: &UVBuffer<f32>,
+    primitive_buffer: &PrimitiveBuffer,
+) {
+    bump_material_apply_generation_for_pass();
+    for idx in 0..transparent_buffer.depthbuffer.len() {
+        let trans_cell = transparent_buffer.depthbuffer[idx];
+        let opaque_depth = opaque_buffer.depthbuffer[idx].depth[0];
+        let dst_cell = &mut opaque_buffer.canvas[idx];
+
+        for depth_layer in (0..DEPTHLAYER).rev() {
+            let pixinfo = transparent_buffer.pixbuffer[trans_cell.pixinfo[depth_layer]];
+            let trans_depth = trans_cell.depth[depth_layer];
+            if trans_depth >= opaque_depth {
+                continue;
+            }
+
+            let mut src_cell = CanvasCell::default();
+            apply_material(
+                pixinfo,
+                material_buffer,
+                texture_buffer,
+                uv_buffer,
+                primitive_buffer,
+                &trans_cell,
+                depth_layer,
+                &mut src_cell,
+            );
+            let mat = &material_buffer.mats[pixinfo.material_id];
+            let src_front = color_to_vec4(&src_cell.front_color);
+            dst_cell.front_color = blend_front(&dst_cell.front_color, &src_front, mat.blend_mode());
+            if mat.glyph_policy() == GlyphPolicy::ReplaceFromShader {
+                dst_cell.glyph = src_cell.glyph;
+            }
+        }
+    }
 }

--- a/src/drawbuffer/mod.rs
+++ b/src/drawbuffer/mod.rs
@@ -8,6 +8,7 @@ use pyo3::{
 use rayon::ThreadPool;
 use std::sync::Arc;
 pub mod drawbuffer;
+pub mod blend;
 use drawbuffer::*;
 use pyo3::types::PyDict;
 pub mod glyphset;
@@ -19,9 +20,11 @@ use segment_cache::*;
 #[pyclass]
 pub struct DrawingBufferPy {
     pub db: DrawBuffer<2, f32>,
+    pub opaque_db: DrawBuffer<1, f32>,
+    pub transparent_db: DrawBuffer<1, f32>,
+    pub legacy_layers: bool,
     max_row: usize,
     max_col: usize,
-    layer_count: usize,
 
     /// When `Some(n)`, parallel material shading uses `n` Rayon threads; `None` means serial-only.
     #[pyo3(get)]
@@ -64,7 +67,7 @@ fn material_parallelism_from_py(spec: Option<Option<usize>>) -> (Option<usize>, 
 #[pymethods]
 impl DrawingBufferPy {
     #[new]
-    #[pyo3(signature = (max_row, max_col, flip_x=false, flip_y=true, material_parallel_threads=-1))]
+    #[pyo3(signature = (max_row, max_col, flip_x=false, flip_y=true, material_parallel_threads=-1, legacy_layers=true))]
     fn new(
         py: Python<'_>,
         max_row: usize,
@@ -72,6 +75,7 @@ impl DrawingBufferPy {
         flip_x: bool,
         flip_y: bool,
         material_parallel_threads: i64,
+        legacy_layers: bool,
     ) -> PyResult<Self> {
         let spec = match material_parallel_threads {
             -1 => None,
@@ -103,11 +107,25 @@ impl DrawingBufferPy {
             &style_class,
         );
         let (material_parallel_threads, material_pool) = material_parallelism_from_py(spec);
+        if legacy_layers {
+            let warnings = py.import("warnings").unwrap();
+            let builtins = py.import("builtins").unwrap();
+            let depwarn = builtins.getattr("DeprecationWarning").unwrap();
+            let _ = warnings.call_method1(
+                "warn",
+                (
+                    "DrawingBufferPy(legacy_layers=True) is deprecated; switch to legacy_layers=False for the new opaque/transparent pass model.",
+                    depwarn,
+                ),
+            );
+        }
         Ok(DrawingBufferPy {
             db: DrawBuffer::new(max_row, max_col, 10.0, flip_x, flip_y),
+            opaque_db: DrawBuffer::new(max_row, max_col, 10.0, flip_x, flip_y),
+            transparent_db: DrawBuffer::new(max_row, max_col, 10.0, flip_x, flip_y),
+            legacy_layers,
             max_row,
             max_col,
-            layer_count: 2,
             material_parallel_threads,
             material_pool,
             segment_class: segment_class.into(),
@@ -123,13 +141,19 @@ impl DrawingBufferPy {
         self.seg_cache.get_cache_size()
     }
     pub fn layer_count(&self) -> usize {
-        self.layer_count
+        if self.legacy_layers {
+            2
+        } else {
+            1
+        }
     }
     pub fn get_flip_x(&self) -> bool {
         self.db.flip_x
     }
     pub fn set_flip_x(&mut self, v: bool) {
         self.db.set_flip_x(v);
+        self.opaque_db.set_flip_x(v);
+        self.transparent_db.set_flip_x(v);
     }
     pub fn get_flip_y(&self) -> bool {
         self.db.flip_y
@@ -137,6 +161,8 @@ impl DrawingBufferPy {
 
     pub fn set_flip_y(&mut self, v: bool) {
         self.db.set_flip_y(v);
+        self.opaque_db.set_flip_y(v);
+        self.transparent_db.set_flip_y(v);
     }
 
     pub fn get_row_count(&self) -> usize {
@@ -157,10 +183,21 @@ impl DrawingBufferPy {
     fn hard_clear(&mut self, init_value: f32) {
         self.db.clear_depth(init_value);
         self.db.clear_pixinfo();
+        self.db.canvas.fill(CANVAS_CELL_INIT);
+        self.opaque_db.clear_depth(init_value);
+        self.opaque_db.clear_pixinfo();
+        self.opaque_db.canvas.fill(CANVAS_CELL_INIT);
+        self.transparent_db.clear_depth(init_value);
+        self.transparent_db.clear_pixinfo();
+        self.transparent_db.canvas.fill(CANVAS_CELL_INIT);
     }
 
     fn get_min_max_depth(&self, py: Python, layer: usize) -> Py<PyTuple> {
-        let mima = self.db.get_min_max_depth(layer);
+        let mima = if self.legacy_layers {
+            self.db.get_min_max_depth(layer)
+        } else {
+            self.opaque_db.get_min_max_depth(0)
+        };
         let tt = PyTuple::new(py, [mima.0, mima.1]).unwrap();
         tt.into()
     }
@@ -192,24 +229,23 @@ impl DrawingBufferPy {
             .unwrap_or_else(Vec2::zeros);
 
         self.db.set_depth_content(
-            row,
-            col,
-            depth,
-            normal,
-            uv,
-            uv_1,
-            node_id,
-            geom_id,
-            material_id,
-            primitive_id,
-            front_facing,
-            line_coord,
-            point_coord_v,
-        )
+            row, col, depth, normal, uv, uv_1, node_id, geom_id, material_id, primitive_id,
+            front_facing, line_coord, point_coord_v,
+        );
+        if !self.legacy_layers {
+            self.opaque_db.set_depth_content(
+                row, col, depth, normal, uv, uv_1, node_id, geom_id, material_id, primitive_id,
+                front_facing, line_coord, point_coord_v,
+            );
+        }
     }
 
     fn get_pix_info_element(&self, py: Python, idx: usize) -> Py<PyDict> {
-        let pix_info_element = self.db.pixbuffer[idx];
+        let pix_info_element = if self.legacy_layers {
+            self.db.pixbuffer[idx]
+        } else {
+            self.opaque_db.pixbuffer[idx]
+        };
         let dict = PyDict::new(py);
 
         let wslice = pix_info_element.uv.as_slice();
@@ -244,10 +280,25 @@ impl DrawingBufferPy {
         col: usize,
         layer: usize,
     ) -> Py<PyDict> {
-        let cell = self.db.get_depth_buffer_cell(row, col);
+        if !self.legacy_layers && layer > 0 {
+            return PyDict::new(py).into();
+        }
+        let cell = if self.legacy_layers {
+            self.db.get_depth_buffer_cell(row, col)
+        } else {
+            let c = self.opaque_db.get_depth_buffer_cell(row, col);
+            crate::drawbuffer::drawbuffer::DepthBufferCell {
+                depth: [c.depth[0], c.depth[0]],
+                pixinfo: [c.pixinfo[0], c.pixinfo[0]],
+            }
+        };
         let dict = PyDict::new(py);
 
-        let pix_info_element = self.db.pixbuffer[cell.pixinfo[layer]];
+        let pix_info_element = if self.legacy_layers {
+            self.db.pixbuffer[cell.pixinfo[layer]]
+        } else {
+            self.opaque_db.pixbuffer[cell.pixinfo[0]]
+        };
 
         // Assuming DepthBufferCell has some fields `field1` and `field2`
         dict.set_item("depth", cell.depth[layer]).unwrap();
@@ -297,11 +348,19 @@ impl DrawingBufferPy {
             a: back_color_tuple[3],
         };
 
-        self.db.set_canvas_content(row, col, frontc, backc, glyph)
+        if self.legacy_layers {
+            self.db.set_canvas_content(row, col, frontc, backc, glyph)
+        } else {
+            self.opaque_db.set_canvas_content(row, col, frontc, backc, glyph)
+        }
     }
 
     fn get_canvas_cell(&self, py: Python, r: usize, c: usize) -> Py<PyDict> {
-        let cell = self.db.get_canvas_cell(r, c);
+        let cell = if self.legacy_layers {
+            self.db.get_canvas_cell(r, c)
+        } else {
+            self.opaque_db.get_canvas_cell(r, c)
+        };
         let dict = PyDict::new(py); // this will be super slow
         dict.set_item("f_r", cell.front_color.r).unwrap();
         dict.set_item("f_g", cell.front_color.g).unwrap();
@@ -328,7 +387,11 @@ impl DrawingBufferPy {
         min_y: usize,
         max_y: usize,
     ) -> Py<PyList> {
-        let canvas = &self.db.canvas;
+        let canvas = if self.legacy_layers {
+            &self.db.canvas
+        } else {
+            &self.opaque_db.canvas
+        };
         let dict = PyDict::new(py);
 
         let ncols = max_x.saturating_sub(min_x);

--- a/src/drawbuffer/mod.rs
+++ b/src/drawbuffer/mod.rs
@@ -19,10 +19,8 @@ use segment_cache::*;
 
 #[pyclass]
 pub struct DrawingBufferPy {
-    pub db: DrawBuffer<2, f32>,
     pub opaque_db: DrawBuffer<1, f32>,
     pub transparent_db: DrawBuffer<1, f32>,
-    pub legacy_layers: bool,
     max_row: usize,
     max_col: usize,
 
@@ -67,7 +65,7 @@ fn material_parallelism_from_py(spec: Option<Option<usize>>) -> (Option<usize>, 
 #[pymethods]
 impl DrawingBufferPy {
     #[new]
-    #[pyo3(signature = (max_row, max_col, flip_x=false, flip_y=true, material_parallel_threads=-1, legacy_layers=true))]
+    #[pyo3(signature = (max_row, max_col, flip_x=false, flip_y=true, material_parallel_threads=-1))]
     fn new(
         py: Python<'_>,
         max_row: usize,
@@ -75,7 +73,6 @@ impl DrawingBufferPy {
         flip_x: bool,
         flip_y: bool,
         material_parallel_threads: i64,
-        legacy_layers: bool,
     ) -> PyResult<Self> {
         let spec = match material_parallel_threads {
             -1 => None,
@@ -107,23 +104,9 @@ impl DrawingBufferPy {
             &style_class,
         );
         let (material_parallel_threads, material_pool) = material_parallelism_from_py(spec);
-        if legacy_layers {
-            let warnings = py.import("warnings").unwrap();
-            let builtins = py.import("builtins").unwrap();
-            let depwarn = builtins.getattr("DeprecationWarning").unwrap();
-            let _ = warnings.call_method1(
-                "warn",
-                (
-                    "DrawingBufferPy(legacy_layers=True) is deprecated; switch to legacy_layers=False for the new opaque/transparent pass model.",
-                    depwarn,
-                ),
-            );
-        }
         Ok(DrawingBufferPy {
-            db: DrawBuffer::new(max_row, max_col, 10.0, flip_x, flip_y),
             opaque_db: DrawBuffer::new(max_row, max_col, 10.0, flip_x, flip_y),
             transparent_db: DrawBuffer::new(max_row, max_col, 10.0, flip_x, flip_y),
-            legacy_layers,
             max_row,
             max_col,
             material_parallel_threads,
@@ -141,35 +124,29 @@ impl DrawingBufferPy {
         self.seg_cache.get_cache_size()
     }
     pub fn layer_count(&self) -> usize {
-        if self.legacy_layers {
-            2
-        } else {
-            1
-        }
+        1
     }
     pub fn get_flip_x(&self) -> bool {
-        self.db.flip_x
+        self.opaque_db.flip_x
     }
     pub fn set_flip_x(&mut self, v: bool) {
-        self.db.set_flip_x(v);
         self.opaque_db.set_flip_x(v);
         self.transparent_db.set_flip_x(v);
     }
     pub fn get_flip_y(&self) -> bool {
-        self.db.flip_y
+        self.opaque_db.flip_y
     }
 
     pub fn set_flip_y(&mut self, v: bool) {
-        self.db.set_flip_y(v);
         self.opaque_db.set_flip_y(v);
         self.transparent_db.set_flip_y(v);
     }
 
     pub fn get_row_count(&self) -> usize {
-        self.db.row_count
+        self.opaque_db.row_count
     }
     pub fn get_col_count(&self) -> usize {
-        self.db.col_count
+        self.opaque_db.col_count
     }
     //set the number of bit for every channel of the front color.
     pub fn set_bit_size_front(&mut self, r: u8, g: u8, b: u8) {
@@ -181,9 +158,6 @@ impl DrawingBufferPy {
     }
 
     fn hard_clear(&mut self, init_value: f32) {
-        self.db.clear_depth(init_value);
-        self.db.clear_pixinfo();
-        self.db.canvas.fill(CANVAS_CELL_INIT);
         self.opaque_db.clear_depth(init_value);
         self.opaque_db.clear_pixinfo();
         self.opaque_db.canvas.fill(CANVAS_CELL_INIT);
@@ -192,12 +166,8 @@ impl DrawingBufferPy {
         self.transparent_db.canvas.fill(CANVAS_CELL_INIT);
     }
 
-    fn get_min_max_depth(&self, py: Python, layer: usize) -> Py<PyTuple> {
-        let mima = if self.legacy_layers {
-            self.db.get_min_max_depth(layer)
-        } else {
-            self.opaque_db.get_min_max_depth(0)
-        };
+    fn get_min_max_depth(&self, py: Python, _layer: usize) -> Py<PyTuple> {
+        let mima = self.opaque_db.get_min_max_depth(0);
         let tt = PyTuple::new(py, [mima.0, mima.1]).unwrap();
         tt.into()
     }
@@ -228,24 +198,14 @@ impl DrawingBufferPy {
             .map(|p| convert_glm_vec2(py, p))
             .unwrap_or_else(Vec2::zeros);
 
-        self.db.set_depth_content(
+        self.opaque_db.set_depth_content(
             row, col, depth, normal, uv, uv_1, node_id, geom_id, material_id, primitive_id,
             front_facing, line_coord, point_coord_v,
         );
-        if !self.legacy_layers {
-            self.opaque_db.set_depth_content(
-                row, col, depth, normal, uv, uv_1, node_id, geom_id, material_id, primitive_id,
-                front_facing, line_coord, point_coord_v,
-            );
-        }
     }
 
     fn get_pix_info_element(&self, py: Python, idx: usize) -> Py<PyDict> {
-        let pix_info_element = if self.legacy_layers {
-            self.db.pixbuffer[idx]
-        } else {
-            self.opaque_db.pixbuffer[idx]
-        };
+        let pix_info_element = self.opaque_db.pixbuffer[idx];
         let dict = PyDict::new(py);
 
         let wslice = pix_info_element.uv.as_slice();
@@ -280,29 +240,17 @@ impl DrawingBufferPy {
         col: usize,
         layer: usize,
     ) -> Py<PyDict> {
-        if !self.legacy_layers && layer > 0 {
+        if layer > 0 {
             return PyDict::new(py).into();
         }
-        let cell = if self.legacy_layers {
-            self.db.get_depth_buffer_cell(row, col)
-        } else {
-            let c = self.opaque_db.get_depth_buffer_cell(row, col);
-            crate::drawbuffer::drawbuffer::DepthBufferCell {
-                depth: [c.depth[0], c.depth[0]],
-                pixinfo: [c.pixinfo[0], c.pixinfo[0]],
-            }
-        };
+        let cell = self.opaque_db.get_depth_buffer_cell(row, col);
         let dict = PyDict::new(py);
 
-        let pix_info_element = if self.legacy_layers {
-            self.db.pixbuffer[cell.pixinfo[layer]]
-        } else {
-            self.opaque_db.pixbuffer[cell.pixinfo[0]]
-        };
+        let pix_info_element = self.opaque_db.pixbuffer[cell.pixinfo[0]];
 
         // Assuming DepthBufferCell has some fields `field1` and `field2`
-        dict.set_item("depth", cell.depth[layer]).unwrap();
-        dict.set_item("pix_info", cell.pixinfo[layer]).unwrap();
+        dict.set_item("depth", cell.depth[0]).unwrap();
+        dict.set_item("pix_info", cell.pixinfo[0]).unwrap();
 
         dict.set_item("uv", pix_info_element.uv.as_slice()).unwrap();
         dict.set_item("uv_1", pix_info_element.uv_1.as_slice())
@@ -348,19 +296,11 @@ impl DrawingBufferPy {
             a: back_color_tuple[3],
         };
 
-        if self.legacy_layers {
-            self.db.set_canvas_content(row, col, frontc, backc, glyph)
-        } else {
-            self.opaque_db.set_canvas_content(row, col, frontc, backc, glyph)
-        }
+        self.opaque_db.set_canvas_content(row, col, frontc, backc, glyph)
     }
 
     fn get_canvas_cell(&self, py: Python, r: usize, c: usize) -> Py<PyDict> {
-        let cell = if self.legacy_layers {
-            self.db.get_canvas_cell(r, c)
-        } else {
-            self.opaque_db.get_canvas_cell(r, c)
-        };
+        let cell = self.opaque_db.get_canvas_cell(r, c);
         let dict = PyDict::new(py); // this will be super slow
         dict.set_item("f_r", cell.front_color.r).unwrap();
         dict.set_item("f_g", cell.front_color.g).unwrap();
@@ -387,11 +327,7 @@ impl DrawingBufferPy {
         min_y: usize,
         max_y: usize,
     ) -> Py<PyList> {
-        let canvas = if self.legacy_layers {
-            &self.db.canvas
-        } else {
-            &self.opaque_db.canvas
-        };
+        let canvas = &self.opaque_db.canvas;
         let dict = PyDict::new(py);
 
         let ncols = max_x.saturating_sub(min_x);

--- a/src/geombuffer/mod.rs
+++ b/src/geombuffer/mod.rs
@@ -4,6 +4,7 @@ use pyo3::{prelude::*, types::PyDict};
 pub struct GeomReferences {
     pub node_id: usize,
     pub material_id: usize,
+    pub transparent: bool,
 }
 
 #[derive(Debug)]
@@ -65,6 +66,7 @@ impl Polygon {
             geom_ref: GeomReferences {
                 node_id: 0,
                 material_id: 0,
+                transparent: false,
             },
             p_start: 0,
             p_count: 0,
@@ -102,6 +104,7 @@ impl GeometryBuffer {
         uv_start: usize,
         node_id: usize,
         material_id: usize,
+        transparent: bool,
     ) -> usize {
         if self.current_size >= self.max_size {
             return self.current_size;
@@ -110,6 +113,7 @@ impl GeometryBuffer {
             geom_ref: GeomReferences {
                 node_id,
                 material_id,
+                transparent,
             },
             point_start: p_start,
             point_count: point_count,
@@ -126,6 +130,7 @@ impl GeometryBuffer {
         uv_start: usize,
         node_id: usize,
         material_id: usize,
+        transparent: bool,
     ) -> usize {
         if self.current_size >= self.max_size {
             return self.current_size;
@@ -135,6 +140,7 @@ impl GeometryBuffer {
             geom_ref: GeomReferences {
                 node_id,
                 material_id,
+                transparent,
             },
             point_start: top_left,
             point_count: 2,
@@ -152,6 +158,7 @@ impl GeometryBuffer {
         uv_idx: usize,
         node_id: usize,
         material_id: usize,
+        transparent: bool,
     ) -> usize {
         if self.current_size >= self.max_size {
             return self.current_size;
@@ -161,6 +168,7 @@ impl GeometryBuffer {
             geom_ref: GeomReferences {
                 node_id,
                 material_id,
+                transparent,
             },
             point_start,
             point_count: point_count,
@@ -177,6 +185,7 @@ impl GeometryBuffer {
         uv_idx: usize,
         node_id: usize,
         material_id: usize,
+        transparent: bool,
     ) -> usize {
         if self.current_size >= self.max_size {
             return self.current_size;
@@ -186,6 +195,7 @@ impl GeometryBuffer {
             geom_ref: GeomReferences {
                 node_id,
                 material_id,
+                transparent,
             },
             point_start: pidx,
             uv_idx,
@@ -203,6 +213,7 @@ impl GeometryBuffer {
         node_id: usize,
         material_id: usize,
         uv_start: usize,
+        transparent: bool,
     ) -> usize {
         if self.current_size >= self.max_size {
             return self.current_size;
@@ -211,6 +222,7 @@ impl GeometryBuffer {
             geom_ref: GeomReferences {
                 node_id,
                 material_id,
+                transparent,
             },
             point_start: p_start,
             point_count: point_count,
@@ -231,6 +243,7 @@ impl GeometryBuffer {
         triangle_count: usize,
         node_id: usize,
         material_id: usize,
+        transparent: bool,
     ) -> usize {
         if self.current_size >= self.max_size {
             return self.current_size;
@@ -240,6 +253,7 @@ impl GeometryBuffer {
             geom_ref: GeomReferences {
                 node_id,
                 material_id,
+                transparent,
             },
             p_start,
             p_count,
@@ -262,6 +276,7 @@ impl GeometryBuffer {
         triangle_count: usize,
         node_id: usize,
         material_id: usize,
+        transparent: bool,
     ) -> usize {
         if self.current_size >= self.max_size {
             return self.current_size;
@@ -271,6 +286,7 @@ impl GeometryBuffer {
             geom_ref: GeomReferences {
                 node_id,
                 material_id,
+                transparent,
             },
             p_start,
             p_count,
@@ -311,6 +327,7 @@ impl GeometryBufferPy {
             },
         }
     }
+    #[pyo3(signature = (p_start, point_count, uv_start, node_id, material_id, transparent=false))]
     fn add_line2d(
         &mut self,
         p_start: usize,
@@ -318,19 +335,22 @@ impl GeometryBufferPy {
         uv_start: usize,
         node_id: usize,
         material_id: usize,
+        transparent: bool,
     ) -> usize {
         self.buffer
-            .add_line2d(p_start, point_count, uv_start, node_id, material_id)
+            .add_line2d(p_start, point_count, uv_start, node_id, material_id, transparent)
     }
+    #[pyo3(signature = (top_left, uv_start, node_id, material_id, transparent=false))]
     fn add_rect2d(
         &mut self,
         top_left: usize,
         uv_start: usize,
         node_id: usize,
         material_id: usize,
+        transparent: bool,
     ) -> usize {
         self.buffer
-            .add_rect2d(top_left, uv_start, node_id, material_id)
+            .add_rect2d(top_left, uv_start, node_id, material_id, transparent)
     }
     fn get_element(&self, py: Python, idx: usize) -> Py<PyDict> {
         geometry_into_dict(py, &self.buffer.content[idx])
@@ -343,6 +363,7 @@ impl GeometryBufferPy {
     fn geometry_count(&self) -> usize {
         self.buffer.current_size
     }
+    #[pyo3(signature = (p_idx, uv_idx, node_id, material_id, transparent=false))]
     fn add_point_3d(
         &mut self,
         _py: Python,
@@ -350,10 +371,12 @@ impl GeometryBufferPy {
         uv_idx: usize,
         node_id: usize,
         material_id: usize,
+        transparent: bool,
     ) -> usize {
         self.buffer
-            .add_point_3d(p_idx, uv_idx, node_id, material_id)
+            .add_point_3d(p_idx, uv_idx, node_id, material_id, transparent)
     }
+    #[pyo3(signature = (p_idx, point_count, uv_idx, node_id, material_id, transparent=false))]
     fn add_points_2d(
         &mut self,
         _py: Python,
@@ -362,10 +385,12 @@ impl GeometryBufferPy {
         uv_idx: usize,
         node_id: usize,
         material_id: usize,
+        transparent: bool,
     ) -> usize {
         self.buffer
-            .add_points_2d(p_idx, point_count, uv_idx, node_id, material_id)
+            .add_points_2d(p_idx, point_count, uv_idx, node_id, material_id, transparent)
     }
+    #[pyo3(signature = (p_start, p_count, uv_start, triangle_start, triangle_count, node_id, material_id, transparent=false))]
     fn add_polygon2d(
         &mut self,
         p_start: usize,
@@ -375,6 +400,7 @@ impl GeometryBufferPy {
         triangle_count: usize,
         node_id: usize,
         material_id: usize,
+        transparent: bool,
     ) -> usize {
         self.buffer.add_polygon2d(
             p_start,
@@ -384,9 +410,11 @@ impl GeometryBufferPy {
             triangle_count,
             node_id,
             material_id,
+            transparent,
         )
     }
 
+    #[pyo3(signature = (p_start, p_count, uv_start, triangle_start, triangle_count, node_id, material_id, transparent=false))]
     fn add_polygon_3d(
         &mut self,
         p_start: usize,
@@ -396,6 +424,7 @@ impl GeometryBufferPy {
         triangle_count: usize,
         node_id: usize,
         material_id: usize,
+        transparent: bool,
     ) -> usize {
         self.buffer.add_polygon_3d(
             p_start,
@@ -405,11 +434,12 @@ impl GeometryBufferPy {
             triangle_count,
             node_id,
             material_id,
+            transparent,
         )
     }
 
     /// Add a 3D line to the geometry buffer
-    #[pyo3(signature = (p_start, point_count, uv_start, node_id, material_id))]
+    #[pyo3(signature = (p_start, point_count, uv_start, node_id, material_id, transparent=false))]
     fn add_line3d(
         &mut self,
         p_start: usize,
@@ -417,9 +447,10 @@ impl GeometryBufferPy {
         uv_start: usize,
         node_id: usize,
         material_id: usize,
+        transparent: bool,
     ) -> usize {
         self.buffer
-            .add_line3d(p_start, point_count, node_id, material_id, uv_start)
+            .add_line3d(p_start, point_count, node_id, material_id, uv_start, transparent)
     }
 
     pub fn update_geometry_material(&mut self, geom_idx: usize, new_material_id: usize) {
@@ -520,6 +551,7 @@ fn geometry_ref_into_dict(py: Python, pi: &GeomReferences) -> Py<PyDict> {
 
     dict.set_item("node_id", pi.node_id).unwrap();
     dict.set_item("material_id", pi.material_id).unwrap();
+    dict.set_item("transparent", pi.transparent).unwrap();
 
     dict.into()
 }

--- a/src/material/materials.rs
+++ b/src/material/materials.rs
@@ -1,4 +1,5 @@
 use crate::drawbuffer::drawbuffer::{CanvasCell, DepthBufferCell, PixInfo};
+use crate::drawbuffer::blend::{BlendMode, GlyphPolicy};
 use crate::material::textured::BaseTexture;
 use crate::primitivbuffer::primitivbuffer::PrimitiveElements;
 use crate::texturebuffer::texture_buffer::TextureBuffer;
@@ -21,6 +22,8 @@ pub enum Material<T = ()> {
         front_color: RGBA,
         back_color: RGBA,
         glyph_idx: u8,
+        blend_mode: BlendMode,
+        glyph_policy: GlyphPolicy,
     },
 
     StaticGlyph {
@@ -51,6 +54,26 @@ impl Material {
                 t.albedo_texture_subid = _subid;
             }
             _ => {}
+        }
+    }
+
+    pub fn blend_mode(&self) -> BlendMode {
+        match self {
+            Material::Texture(t) => t.blend_mode,
+            Material::BaseTexture(t) => t.blend_mode,
+            Material::StaticColor { blend_mode, .. } => *blend_mode,
+            Material::Shader(s) => s.blend_mode,
+            _ => BlendMode::Replace,
+        }
+    }
+
+    pub fn glyph_policy(&self) -> GlyphPolicy {
+        match self {
+            Material::Texture(t) => t.glyph_policy,
+            Material::BaseTexture(t) => t.glyph_policy,
+            Material::StaticColor { glyph_policy, .. } => *glyph_policy,
+            Material::Shader(s) => s.glyph_policy,
+            _ => GlyphPolicy::PreserveExisting,
         }
     }
 }
@@ -169,6 +192,8 @@ impl<
                 front_color,
                 back_color,
                 glyph_idx,
+                blend_mode: _,
+                glyph_policy: _,
             } => {
                 if *front {
                     cell.front_color.copy_from(front_color);

--- a/src/material/materials_py.rs
+++ b/src/material/materials_py.rs
@@ -7,12 +7,53 @@ use pyo3::{
     Bound, Py, PyResult, Python,
 };
 
+use crate::drawbuffer::blend::{BlendMode, GlyphPolicy};
 use crate::material::materials::Material;
 use crate::material::shader_material::{ShaderMaterial, ShaderSeedRegisters};
 use crate::ttsl::{ttslpy::convert_and_fill_register, Registers};
 use crate::material::textured::BaseTexture;
 use crate::texturebuffer;
 use crate::texturebuffer::toglyph_methods_py::ToGlyphMethodPy;
+
+fn parse_blend_mode(input: &str) -> PyResult<BlendMode> {
+    match input {
+        "replace" => Ok(BlendMode::Replace),
+        "alpha_blend" => Ok(BlendMode::AlphaBlend),
+        "additive" => Ok(BlendMode::Additive),
+        "glyph_dither" => Ok(BlendMode::GlyphDither),
+        "half_block_composite" => Ok(BlendMode::HalfBlockComposite),
+        _ => Err(PyValueError::new_err(
+            "blend_mode must be one of: replace, alpha_blend, additive, glyph_dither, half_block_composite",
+        )),
+    }
+}
+
+fn blend_mode_to_str(mode: BlendMode) -> &'static str {
+    match mode {
+        BlendMode::Replace => "replace",
+        BlendMode::AlphaBlend => "alpha_blend",
+        BlendMode::Additive => "additive",
+        BlendMode::GlyphDither => "glyph_dither",
+        BlendMode::HalfBlockComposite => "half_block_composite",
+    }
+}
+
+fn parse_glyph_policy(input: &str) -> PyResult<GlyphPolicy> {
+    match input {
+        "preserve_existing" => Ok(GlyphPolicy::PreserveExisting),
+        "replace_from_shader" => Ok(GlyphPolicy::ReplaceFromShader),
+        _ => Err(PyValueError::new_err(
+            "glyph_policy must be one of: preserve_existing, replace_from_shader",
+        )),
+    }
+}
+
+fn glyph_policy_to_str(policy: GlyphPolicy) -> &'static str {
+    match policy {
+        GlyphPolicy::PreserveExisting => "preserve_existing",
+        GlyphPolicy::ReplaceFromShader => "replace_from_shader",
+    }
+}
 
 #[pyclass(subclass)]
 #[derive(Clone)]
@@ -57,6 +98,8 @@ pub struct BaseTexturePy {
     pub back_uv_0: bool,
     #[pyo3(get, set)]
     pub glyph_method: ToGlyphMethodPy,
+    blend_mode: BlendMode,
+    glyph_policy: GlyphPolicy,
 }
 impl BaseTexturePy {
     pub fn to_native(&self) -> BaseTexture {
@@ -72,13 +115,15 @@ impl BaseTexturePy {
             back_uv_0: self.back_uv_0,
             glyph_uv_0: self.glyph_uv_0,
             to_glyph_method: self.glyph_method.to_method(), //self.glyph_method.to_method(),
+            blend_mode: self.blend_mode,
+            glyph_policy: self.glyph_policy,
         }
     }
 }
 #[pymethods]
 impl BaseTexturePy {
     #[new]
-    #[pyo3(signature = (albedo_texture_idx=0, albedo_texture_subid=0, glyph_texture_idx=0, glyph_texture_subid=0, front=true, back=true, glyph=true, front_uv_0=true, back_uv_0=true, glyph_uv_0=true, glyph_method=None))]
+    #[pyo3(signature = (albedo_texture_idx=0, albedo_texture_subid=0, glyph_texture_idx=0, glyph_texture_subid=0, front=true, back=true, glyph=true, front_uv_0=true, back_uv_0=true, glyph_uv_0=true, glyph_method=None, blend_mode=None, glyph_policy=None))]
     fn new(
         albedo_texture_idx: usize,
         albedo_texture_subid: usize,
@@ -91,8 +136,20 @@ impl BaseTexturePy {
         back_uv_0: bool,
         glyph_uv_0: bool,
         glyph_method: Option<ToGlyphMethodPy>,
+        blend_mode: Option<&str>,
+        glyph_policy: Option<&str>,
     ) -> PyClassInitializer<Self> {
         let parent = MaterialPy::new();
+        let blend_mode = blend_mode
+            .map(parse_blend_mode)
+            .transpose()
+            .unwrap_or(None)
+            .unwrap_or(BlendMode::Replace);
+        let glyph_policy = glyph_policy
+            .map(parse_glyph_policy)
+            .transpose()
+            .unwrap_or(None)
+            .unwrap_or(GlyphPolicy::PreserveExisting);
         let glyph_method = match glyph_method {
             Some(gm) => gm,
             None => ToGlyphMethodPy {
@@ -113,7 +170,31 @@ impl BaseTexturePy {
             back_uv_0,
             glyph_uv_0,
             glyph_method: glyph_method,
+            blend_mode,
+            glyph_policy,
         })
+    }
+
+    #[getter]
+    fn blend_mode(&self) -> String {
+        blend_mode_to_str(self.blend_mode).to_string()
+    }
+
+    #[setter]
+    fn set_blend_mode(&mut self, value: &str) -> PyResult<()> {
+        self.blend_mode = parse_blend_mode(value)?;
+        Ok(())
+    }
+
+    #[getter]
+    fn glyph_policy(&self) -> String {
+        glyph_policy_to_str(self.glyph_policy).to_string()
+    }
+
+    #[setter]
+    fn set_glyph_policy(&mut self, value: &str) -> PyResult<()> {
+        self.glyph_policy = parse_glyph_policy(value)?;
+        Ok(())
     }
 }
 
@@ -134,11 +215,14 @@ pub struct StaticColorPy {
 
     #[pyo3(get, set)]
     glyph_idx: u8,
+    blend_mode: BlendMode,
+    glyph_policy: GlyphPolicy,
 }
 
 #[pymethods]
 impl StaticColorPy {
     #[new]
+    #[pyo3(signature = (front, back, glyph, front_color, back_color, glyph_idx, blend_mode=None, glyph_policy=None))]
     fn new(
         front: bool,
         back: bool,
@@ -146,8 +230,20 @@ impl StaticColorPy {
         front_color: (u8, u8, u8, u8),
         back_color: (u8, u8, u8, u8),
         glyph_idx: u8,
+        blend_mode: Option<&str>,
+        glyph_policy: Option<&str>,
     ) -> PyClassInitializer<Self> {
         let parent = MaterialPy::new();
+        let blend_mode = blend_mode
+            .map(parse_blend_mode)
+            .transpose()
+            .unwrap_or(None)
+            .unwrap_or(BlendMode::Replace);
+        let glyph_policy = glyph_policy
+            .map(parse_glyph_policy)
+            .transpose()
+            .unwrap_or(None)
+            .unwrap_or(GlyphPolicy::PreserveExisting);
         PyClassInitializer::from(parent).add_subclass(StaticColorPy {
             front,
             back,
@@ -155,6 +251,8 @@ impl StaticColorPy {
             front_color,
             back_color,
             glyph_idx,
+            blend_mode,
+            glyph_policy,
         })
     }
 }
@@ -177,6 +275,8 @@ impl StaticColorPy {
                 a: self.back_color.3,
             },
             glyph_idx: self.glyph_idx,
+            blend_mode: self.blend_mode,
+            glyph_policy: self.glyph_policy,
         }
     }
 }
@@ -195,6 +295,8 @@ pub struct ShaderPy {
     pub line_coord_f32_reg: Option<usize>,
     pub point_coord_v2_reg: Option<usize>,
     pub default_glyph: Option<u8>,
+    pub blend_mode: BlendMode,
+    pub glyph_policy: GlyphPolicy,
     /// Same layout as ``RegisterSettings.get_register_list()`` (list of 6 dicts), or ``None``.
     #[pyo3(get, set)]
     pub register_seed: Option<Py<PyAny>>,
@@ -245,7 +347,9 @@ impl ShaderPy {
             .with_frag_depth_f32_reg(self.frag_depth_f32_reg)
             .with_line_coord_f32_reg(self.line_coord_f32_reg)
             .with_point_coord_v2_reg(self.point_coord_v2_reg)
-            .with_default_glyph(self.default_glyph);
+            .with_default_glyph(self.default_glyph)
+            .with_blend_mode(self.blend_mode)
+            .with_glyph_policy(self.glyph_policy);
         if let Some(regs) = seed_registers {
             mat = mat.with_seed_registers(ShaderSeedRegisters::from_registers(regs));
         }
@@ -256,7 +360,7 @@ impl ShaderPy {
 #[pymethods]
 impl ShaderPy {
     #[new]
-    #[pyo3(signature = (bytecode, time_f32_reg=None, delta_time_f32_reg=None, resolution_v2_reg=None, front_facing_bool_reg=None, frag_depth_f32_reg=None, line_coord_f32_reg=None, point_coord_v2_reg=None, default_glyph=None, register_seed=None, frame_i32_reg=None, near_f32_reg=None, far_f32_reg=None))]
+    #[pyo3(signature = (bytecode, time_f32_reg=None, delta_time_f32_reg=None, resolution_v2_reg=None, front_facing_bool_reg=None, frag_depth_f32_reg=None, line_coord_f32_reg=None, point_coord_v2_reg=None, default_glyph=None, register_seed=None, frame_i32_reg=None, near_f32_reg=None, far_f32_reg=None, blend_mode=None, glyph_policy=None))]
     fn new(
         bytecode: &Bound<'_, PyBytes>,
         time_f32_reg: Option<usize>,
@@ -271,9 +375,21 @@ impl ShaderPy {
         frame_i32_reg: Option<usize>,
         near_f32_reg: Option<usize>,
         far_f32_reg: Option<usize>,
+        blend_mode: Option<&str>,
+        glyph_policy: Option<&str>,
     ) -> PyClassInitializer<Self> {
         let parent = MaterialPy::new();
         let bytes = bytecode.as_bytes();
+        let blend_mode = blend_mode
+            .map(parse_blend_mode)
+            .transpose()
+            .unwrap_or(None)
+            .unwrap_or(BlendMode::Replace);
+        let glyph_policy = glyph_policy
+            .map(parse_glyph_policy)
+            .transpose()
+            .unwrap_or(None)
+            .unwrap_or(GlyphPolicy::PreserveExisting);
         PyClassInitializer::from(parent).add_subclass(ShaderPy {
             bytecode: bytes.to_vec(),
             time_f32_reg,
@@ -287,6 +403,8 @@ impl ShaderPy {
             line_coord_f32_reg,
             point_coord_v2_reg,
             default_glyph,
+            blend_mode,
+            glyph_policy,
             register_seed,
         })
     }
@@ -409,6 +527,28 @@ impl ShaderPy {
     #[setter]
     fn set_default_glyph(&mut self, value: Option<u8>) {
         self.default_glyph = value;
+    }
+
+    #[getter]
+    fn blend_mode(&self) -> String {
+        blend_mode_to_str(self.blend_mode).to_string()
+    }
+
+    #[setter]
+    fn set_blend_mode(&mut self, value: &str) -> PyResult<()> {
+        self.blend_mode = parse_blend_mode(value)?;
+        Ok(())
+    }
+
+    #[getter]
+    fn glyph_policy(&self) -> String {
+        glyph_policy_to_str(self.glyph_policy).to_string()
+    }
+
+    #[setter]
+    fn set_glyph_policy(&mut self, value: &str) -> PyResult<()> {
+        self.glyph_policy = parse_glyph_policy(value)?;
+        Ok(())
     }
 }
 

--- a/src/material/mod.rs
+++ b/src/material/mod.rs
@@ -3,6 +3,7 @@ use super::texturebuffer::RGBA;
 use crate::vertexbuffer::uv_buffer::UVBuffer;
 use crate::{
     drawbuffer::drawbuffer::{CanvasCell, DepthBufferCell, PixInfo},
+    drawbuffer::blend::{BlendMode, GlyphPolicy},
     primitivbuffer::primitivbuffer::PrimitiveBuffer,
     utils::convert_tuple_rgba,
 };
@@ -69,6 +70,8 @@ impl MaterialBuffer {
             front_color,
             back_color,
             glyph_idx,
+            blend_mode: BlendMode::Replace,
+            glyph_policy: GlyphPolicy::PreserveExisting,
         };
 
         self.current_size += 1;

--- a/src/material/shader_material.rs
+++ b/src/material/shader_material.rs
@@ -4,7 +4,10 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use nalgebra_glm::{vec2, vec3, Vec2, Vec3, Vec4};
 
 use crate::{
-    drawbuffer::drawbuffer::{CanvasCell, Color, DepthBufferCell, PixInfo},
+    drawbuffer::{
+        blend::{BlendMode, GlyphPolicy},
+        drawbuffer::{CanvasCell, Color, DepthBufferCell, PixInfo},
+    },
     primitivbuffer::primitivbuffer::PrimitiveElements,
     texturebuffer::texture_buffer::TextureBuffer,
     ttsl::{decode_instrs_256, run_ttsl, Instr, Registers},
@@ -28,6 +31,8 @@ pub struct ShaderMaterial {
     pub seed_regs: ShaderSeedRegisters,
     pub input_binding: ShaderInputBinding,
     pub default_glyph: Option<u8>,
+    pub blend_mode: BlendMode,
+    pub glyph_policy: GlyphPolicy,
 }
 
 #[derive(Clone)]
@@ -228,6 +233,8 @@ impl ShaderMaterial {
             seed_regs: ShaderSeedRegisters::default(),
             input_binding: ShaderInputBinding::default(),
             default_glyph: None,
+            blend_mode: BlendMode::Replace,
+            glyph_policy: GlyphPolicy::PreserveExisting,
         }
     }
 
@@ -338,6 +345,16 @@ impl ShaderMaterial {
 
     pub fn with_default_glyph(mut self, default_glyph: Option<u8>) -> Self {
         self.default_glyph = default_glyph;
+        self
+    }
+
+    pub fn with_blend_mode(mut self, blend_mode: BlendMode) -> Self {
+        self.blend_mode = blend_mode;
+        self
+    }
+
+    pub fn with_glyph_policy(mut self, glyph_policy: GlyphPolicy) -> Self {
+        self.glyph_policy = glyph_policy;
         self
     }
 }

--- a/src/material/textured.rs
+++ b/src/material/textured.rs
@@ -2,6 +2,7 @@ use nalgebra_glm::Vec3;
 
 use crate::{
     drawbuffer::{
+        blend::{BlendMode, GlyphPolicy},
         drawbuffer::{CanvasCell, Color, DepthBufferCell, PixInfo},
         glyphset::HALF_UPPER_BLOCK,
     },
@@ -30,6 +31,8 @@ pub struct BaseTexture {
     pub back_uv_0: bool,
     pub glyph_uv_0: bool,
     pub to_glyph_method: ToGlyphMethod,
+    pub blend_mode: BlendMode,
+    pub glyph_policy: GlyphPolicy,
 }
 impl BaseTexture {
     pub fn new(
@@ -44,6 +47,8 @@ impl BaseTexture {
         back_uv_0: bool,
         glyph_uv_0: bool,
         to_glyph_method: ToGlyphMethod,
+        blend_mode: BlendMode,
+        glyph_policy: GlyphPolicy,
     ) -> Self {
         Self {
             albedo_texture_idx,
@@ -57,6 +62,8 @@ impl BaseTexture {
             back_uv_0,
             glyph_uv_0,
             to_glyph_method: to_glyph_method,
+            blend_mode,
+            glyph_policy,
         }
     }
 }
@@ -250,12 +257,16 @@ fn blend_color_to_cell_single(cell_color: &mut Color, color: &RGBA) {
 pub struct Textured {
     pub albedo_texture_idx: usize,
     pub glyph_idx: u8,
+    pub blend_mode: BlendMode,
+    pub glyph_policy: GlyphPolicy,
 }
 impl Textured {
     pub fn new(albedo_texture_idx: usize, glyph_idx: u8) -> Self {
         Self {
             albedo_texture_idx,
             glyph_idx,
+            blend_mode: BlendMode::Replace,
+            glyph_policy: GlyphPolicy::PreserveExisting,
         }
     }
 }

--- a/src/primitiv_building/line_clipping.rs
+++ b/src/primitiv_building/line_clipping.rs
@@ -88,6 +88,7 @@ pub fn line3d_as_primitive<const PIXCOUNT: usize, DEPTHACC: Number>(
                 Vec4::new(point_b.x, point_b.y, pdivb.z, pdivb.w),
                 Vec3::new(0.0, 0.0, 1.0),
                 Vec2::new(1.0, 1.0).xy(),
+                geom_ref.transparent,
             );
         }
         None => {}

--- a/src/primitiv_building/mod.rs
+++ b/src/primitiv_building/mod.rs
@@ -4,7 +4,7 @@ use pyo3::{exceptions::PyValueError, pyfunction, PyRefMut, PyResult};
 
 use crate::{
     drawbuffer::{
-        drawbuffer::{apply_material_on, apply_material_on_parallel, DrawBuffer},
+        drawbuffer::{apply_material_on, apply_material_on_parallel, apply_material_transparent_on, DrawBuffer},
         DrawingBufferPy,
     },
     geombuffer::{GeometryBuffer, GeometryBufferPy},
@@ -127,6 +127,7 @@ pub fn build_primitives<const PIXCOUNT: usize, DEPTHACC: Number>(
                         p.geom_ref.material_id,
                         top_left_vertex,
                         bottom_right_vertex,
+                        p.geom_ref.transparent,
                     );
                 };
             }
@@ -156,6 +157,7 @@ pub fn build_primitives<const PIXCOUNT: usize, DEPTHACC: Number>(
                             screen_ccord.x,
                             point_clip_space.z,
                             p.uv_idx + point_idx,
+                            p.geom_ref.transparent,
                         );
                     }
                 }
@@ -200,6 +202,7 @@ pub fn build_primitives<const PIXCOUNT: usize, DEPTHACC: Number>(
                             pb_pos,
                             normal_b,
                             uvb_clip,
+                            p.geom_ref.transparent,
                         );
                     }
                 }
@@ -230,6 +233,7 @@ pub fn build_primitives<const PIXCOUNT: usize, DEPTHACC: Number>(
                         screen_ccord.x,
                         v.z,
                         0,
+                        p.geom_ref.transparent,
                     );
                 }
             }
@@ -315,6 +319,7 @@ pub fn build_primitives<const PIXCOUNT: usize, DEPTHACC: Number>(
                                 normal: normal_vec,
                                 uv: uvs[2],
                             },
+                            polygon.geom_ref.transparent,
                         );
                     }
                 }
@@ -356,48 +361,100 @@ pub fn build_primitives_py(
 }
 
 #[pyfunction]
+#[pyo3(signature = (material_buffer, texturebuffer, vertex_buffer, primitivbuffer, draw_buffer_py, pass_filter=None))]
 pub fn apply_material_py(
     material_buffer: &MaterialBufferPy,
     texturebuffer: &TextureBufferPy,
     vertex_buffer: &VertexBufferPy,
     primitivbuffer: &PrimitiveBufferPy,
     mut draw_buffer_py: PyRefMut<'_, DrawingBufferPy>,
+    pass_filter: Option<&str>,
 ) {
-    apply_material_on(
-        &mut draw_buffer_py.db,
-        &material_buffer.content,
-        &texturebuffer.data,
-        &vertex_buffer.uv_array,
-        &primitivbuffer.content,
-    );
+    let draw_buf: &mut DrawingBufferPy = &mut draw_buffer_py;
+    if draw_buf.legacy_layers {
+        apply_material_on(
+            &mut draw_buf.db,
+            &material_buffer.content,
+            &texturebuffer.data,
+            &vertex_buffer.uv_array,
+            &primitivbuffer.content,
+        );
+        return;
+    }
+
+    match pass_filter {
+        Some("transparent") => {
+            let transparent_db = &draw_buf.transparent_db;
+            let opaque_db = &mut draw_buf.opaque_db;
+            apply_material_transparent_on(
+                transparent_db,
+                opaque_db,
+                &material_buffer.content,
+                &texturebuffer.data,
+                &vertex_buffer.uv_array,
+                &primitivbuffer.content,
+            )
+        }
+        _ => apply_material_on(
+            &mut draw_buf.opaque_db,
+            &material_buffer.content,
+            &texturebuffer.data,
+            &vertex_buffer.uv_array,
+            &primitivbuffer.content,
+        ),
+    }
 }
 
 #[pyfunction]
+#[pyo3(signature = (material_buffer, texturebuffer, vertex_buffer, primitivbuffer, draw_buffer_py, pass_filter=None))]
 pub fn apply_material_py_parallel(
     material_buffer: &MaterialBufferPy,
     texturebuffer: &TextureBufferPy,
     vertex_buffer: &VertexBufferPy,
     primitivbuffer: &PrimitiveBufferPy,
     mut draw_buffer_py: PyRefMut<'_, DrawingBufferPy>,
+    pass_filter: Option<&str>,
 ) -> PyResult<()> {
-    let DrawingBufferPy {
-        db,
-        material_pool,
-        ..
-    } = &mut *draw_buffer_py;
+    let draw_buf: &mut DrawingBufferPy = &mut draw_buffer_py;
+    let material_pool = &draw_buf.material_pool;
     let pool = material_pool.as_ref().ok_or_else(|| {
         PyValueError::new_err(
             "DrawingBufferPy has no material thread pool (material_parallel_threads=None); \
              use apply_material_py for serial shading",
         )
     })?;
-    apply_material_on_parallel(
-        pool.as_ref(),
-        db,
-        &material_buffer.content,
-        &texturebuffer.data,
-        &vertex_buffer.uv_array,
-        &primitivbuffer.content,
-    );
+    if draw_buf.legacy_layers {
+        apply_material_on_parallel(
+            pool.as_ref(),
+            &mut draw_buf.db,
+            &material_buffer.content,
+            &texturebuffer.data,
+            &vertex_buffer.uv_array,
+            &primitivbuffer.content,
+        );
+        return Ok(());
+    }
+
+    if matches!(pass_filter, Some("transparent")) {
+        let transparent_db = &draw_buf.transparent_db;
+        let opaque_db = &mut draw_buf.opaque_db;
+        apply_material_transparent_on(
+            transparent_db,
+            opaque_db,
+            &material_buffer.content,
+            &texturebuffer.data,
+            &vertex_buffer.uv_array,
+            &primitivbuffer.content,
+        );
+    } else {
+        apply_material_on_parallel(
+            pool.as_ref(),
+            &mut draw_buf.opaque_db,
+            &material_buffer.content,
+            &texturebuffer.data,
+            &vertex_buffer.uv_array,
+            &primitivbuffer.content,
+        );
+    }
     Ok(())
 }

--- a/src/primitiv_building/mod.rs
+++ b/src/primitiv_building/mod.rs
@@ -355,7 +355,7 @@ pub fn build_primitives_py(
         &vbpy.triangle_buffer3d,
         &trbuffer_py.data,
         &vbpy.uv_array,
-        &dbpy.db,
+        &dbpy.opaque_db,
         prim_content,
     );
 }
@@ -371,16 +371,6 @@ pub fn apply_material_py(
     pass_filter: Option<&str>,
 ) {
     let draw_buf: &mut DrawingBufferPy = &mut draw_buffer_py;
-    if draw_buf.legacy_layers {
-        apply_material_on(
-            &mut draw_buf.db,
-            &material_buffer.content,
-            &texturebuffer.data,
-            &vertex_buffer.uv_array,
-            &primitivbuffer.content,
-        );
-        return;
-    }
 
     match pass_filter {
         Some("transparent") => {
@@ -423,18 +413,6 @@ pub fn apply_material_py_parallel(
              use apply_material_py for serial shading",
         )
     })?;
-    if draw_buf.legacy_layers {
-        apply_material_on_parallel(
-            pool.as_ref(),
-            &mut draw_buf.db,
-            &material_buffer.content,
-            &texturebuffer.data,
-            &vertex_buffer.uv_array,
-            &primitivbuffer.content,
-        );
-        return Ok(());
-    }
-
     if matches!(pass_filter, Some("transparent")) {
         let transparent_db = &draw_buf.transparent_db;
         let opaque_db = &mut draw_buf.opaque_db;

--- a/src/primitiv_building/triangle_3d.rs
+++ b/src/primitiv_building/triangle_3d.rs
@@ -102,6 +102,7 @@ pub fn polygon3d_as_primitive_triangles<const PIXCOUNT: usize, DEPTHACC: Number>
                     normal_view,
                     uvs[2] * vccdiv.w,
                 ),
+                polygon.geom_ref.transparent,
             );
         }
     }

--- a/src/primitivbuffer/mod.rs
+++ b/src/primitivbuffer/mod.rs
@@ -38,6 +38,7 @@ impl PrimitiveBufferPy {
         self.content.current_size
     }
 
+    #[pyo3(signature = (node_id, geometry_id, material_id, row, col, depth, uv, transparent=false))]
     fn add_point(
         &mut self,
         node_id: usize,
@@ -47,10 +48,21 @@ impl PrimitiveBufferPy {
         col: f32,
         depth: f32,
         uv: usize,
+        transparent: bool,
     ) -> usize {
         self.content
-            .add_point(node_id, geometry_id, material_id, row, col, depth, uv)
+            .add_point(
+                node_id,
+                geometry_id,
+                material_id,
+                row,
+                col,
+                depth,
+                uv,
+                transparent,
+            )
     }
+    #[pyo3(signature = (node_id, geometry_id, material_id, pa, normal_a, uv_a, pb, normal_b, uv_b, transparent=false))]
     fn add_line(
         &mut self,
         py: Python,
@@ -63,6 +75,7 @@ impl PrimitiveBufferPy {
         pb: Py<PyAny>,
         normal_b: Py<PyAny>,
         uv_b: Py<PyAny>,
+        transparent: bool,
     ) -> usize {
         self.content.add_line(
             node_id,
@@ -74,9 +87,11 @@ impl PrimitiveBufferPy {
             convert_glm_vec4(py, pb),
             convert_glm_vec3(py, normal_b),
             convert_glm_vec2(py, uv_b),
+            transparent,
         )
     }
 
+    #[pyo3(signature = (node_id, geometry_id, material_id, p_a_row, p_a_col, p_a_depth, p_b_row, p_b_col, p_b_depth, p_c_row, p_c_col, p_c_depth, transparent=false))]
     fn add_triangle(
         &mut self,
         node_id: usize,
@@ -91,6 +106,7 @@ impl PrimitiveBufferPy {
         p_c_row: f32,
         p_c_col: f32,
         p_c_depth: f32,
+        transparent: bool,
     ) -> usize {
         let va = Vertex::new(
             vec4(p_a_col, p_a_row, p_a_depth, 1.0),
@@ -109,11 +125,11 @@ impl PrimitiveBufferPy {
         );
 
         self.content
-            .add_triangle(node_id, geometry_id, material_id, va, vb, vc)
+            .add_triangle(node_id, geometry_id, material_id, va, vb, vc, transparent)
     }
 
     #[pyo3(signature = ( node_id, geometry_id, material_id, top, left, top_left_depth, bottom, right, bottom_right_depth,
-        top_left_uv= (0.0, 0.0), bottom_right_uv= (1.0, 1.0) ))]
+        top_left_uv= (0.0, 0.0), bottom_right_uv= (1.0, 1.0), transparent=false ))]
     fn add_rect(
         &mut self,
         node_id: usize,
@@ -127,6 +143,7 @@ impl PrimitiveBufferPy {
         bottom_right_depth: f32,
         top_left_uv: (f32, f32),
         bottom_right_uv: (f32, f32),
+        transparent: bool,
     ) -> usize {
         let top_left = Vertex::new(
             vec4(left, top, top_left_depth, 1.0),
@@ -139,7 +156,14 @@ impl PrimitiveBufferPy {
             vec2(bottom_right_uv.0, bottom_right_uv.1),
         );
         self.content
-            .add_rect(node_id, geometry_id, material_id, top_left, bottom_right)
+            .add_rect(
+                node_id,
+                geometry_id,
+                material_id,
+                top_left,
+                bottom_right,
+                transparent,
+            )
     }
 
     fn get_primitive(&self, py: Python, idx: usize) -> Py<PyDict> {
@@ -207,6 +231,7 @@ fn into_dict(_py: Python, primitive_ref: &PrimitivReferences, dict: &Bound<PyDic
         .unwrap();
     dict.set_item("primitive_id", primitive_ref.primitive_id)
         .unwrap();
+    dict.set_item("transparent", primitive_ref.transparent).unwrap();
 }
 
 #[allow(dead_code)]

--- a/src/primitivbuffer/primitiv_triangle.rs
+++ b/src/primitivbuffer/primitiv_triangle.rs
@@ -27,7 +27,7 @@ impl PTriangle3D {
     }
     pub fn zero() -> Self {
         Self {
-            primitive_reference: PrimitivReferences::new(0, 0, 0, 0),
+            primitive_reference: PrimitivReferences::new(0, 0, 0, 0, false),
             pa: Vertex::zero(),
             pb: Vertex::zero(),
             pc: Vertex::zero(),

--- a/src/primitivbuffer/primitivbuffer.rs
+++ b/src/primitivbuffer/primitivbuffer.rs
@@ -116,6 +116,7 @@ pub struct PrimitivReferences {
     pub material_id: usize,
     pub geometry_id: usize,
     pub primitive_id: usize,
+    pub transparent: bool,
 }
 
 impl PrimitivReferences {
@@ -124,12 +125,14 @@ impl PrimitivReferences {
         material_id: usize,
         geometry_id: usize,
         primitive_id: usize,
+        transparent: bool,
     ) -> Self {
         Self {
             node_id,
             material_id,
             geometry_id,
             primitive_id,
+            transparent,
         }
     }
 }
@@ -205,6 +208,7 @@ impl PrimitiveBuffer {
         material_id: usize,
         top_left: Vertex,
         bottom_right: Vertex,
+        transparent: bool,
     ) -> usize {
         if self.current_size == self.max_size {
             return self.current_size;
@@ -215,6 +219,7 @@ impl PrimitiveBuffer {
             material_id,
             node_id,
             primitive_id: self.current_size,
+            transparent,
         };
 
         self.content[self.current_size] =
@@ -232,6 +237,7 @@ impl PrimitiveBuffer {
         pa: Vertex,
         pb: Vertex,
         pc: Vertex,
+        transparent: bool,
     ) -> usize {
         if self.current_size == self.max_size {
             return self.current_size;
@@ -242,6 +248,7 @@ impl PrimitiveBuffer {
             material_id,
             node_id,
             primitive_id: self.current_size,
+            transparent,
         };
 
         self.content[self.current_size] =
@@ -261,6 +268,7 @@ impl PrimitiveBuffer {
         col: f32,
         depth: f32,
         uv: usize,
+        transparent: bool,
     ) -> usize {
         if self.current_size == self.max_size {
             return self.current_size;
@@ -270,6 +278,7 @@ impl PrimitiveBuffer {
             material_id,
             node_id,
             primitive_id: self.current_size,
+            transparent,
         };
 
         let apoint = PrimitiveElements::Point {
@@ -294,6 +303,7 @@ impl PrimitiveBuffer {
         pos_b: Vec4,
         normal_b: Vec3,
         uv_b: Vec2,
+        transparent: bool,
     ) -> usize {
         let elem = PrimitiveElements::Line {
             fds: PrimitivReferences {
@@ -301,6 +311,7 @@ impl PrimitiveBuffer {
                 material_id,
                 node_id,
                 primitive_id: self.current_size,
+                transparent,
             },
             pa: Vertex::new(pos_a, normal_a, uv_a),
             pb: Vertex::new(pos_b, normal_b, uv_b),

--- a/src/raster/mod.rs
+++ b/src/raster/mod.rs
@@ -22,6 +22,27 @@ use raster_triangle_tomato::*;
 pub mod vertex;
 use vertex::*;
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PassTag {
+    Opaque,
+    Transparent,
+}
+
+fn primitive_matches_pass(element: &PrimitiveElements, pass: Option<PassTag>) -> bool {
+    let is_transparent = match element {
+        PrimitiveElements::Line { fds, .. } => fds.transparent,
+        PrimitiveElements::Point { fds, .. } => fds.transparent,
+        PrimitiveElements::Static { fds, .. } => fds.transparent,
+        PrimitiveElements::Triangle3D(t) => t.primitive_reference.transparent,
+        PrimitiveElements::Rect(r) => r.primitive_reference.transparent,
+    };
+    match pass {
+        None => true,
+        Some(PassTag::Opaque) => !is_transparent,
+        Some(PassTag::Transparent) => is_transparent,
+    }
+}
+
 // function that "set stuff" in the drawing buffer; assuming its a double raster
 fn set_pixel_double_weights<DEPTHACC: RealNumber, const DEPTHCOUNT: usize>(
     prim_ref: &PrimitivReferences,
@@ -137,23 +158,52 @@ pub fn raster_all<const DEPTHCOUNT: usize>(
     primitivbuffer: &PrimitiveBuffer,
     vertexbuffer: &VertexBuffer<Vec4>,
     drawing_buffer: &mut DrawBuffer<DEPTHCOUNT, f32>,
+    pass_filter: Option<PassTag>,
 ) {
     for primitiv_idx in 0..primitivbuffer.current_size {
         let element = primitivbuffer.content[primitiv_idx];
-
-        raster_element(&element, vertexbuffer, drawing_buffer)
+        if primitive_matches_pass(&element, pass_filter) {
+            raster_element(&element, vertexbuffer, drawing_buffer)
+        }
     }
 }
 
 #[pyfunction]
+#[pyo3(signature = (pb, vbuffpy, db, pass_filter=None))]
 pub fn raster_all_py(
     _py: Python,
     pb: &PrimitiveBufferPy,
     vbuffpy: &VertexBufferPy,
     mut db: PyRefMut<'_, DrawingBufferPy>,
+    pass_filter: Option<&str>,
 ) {
     let primitivbuffer = &pb.content;
 
-    let drawing_buffer = &mut db.db;
-    raster_all(primitivbuffer, &vbuffpy.buffer3d, drawing_buffer);
+    let pass = match pass_filter {
+        Some("opaque") => Some(PassTag::Opaque),
+        Some("transparent") => Some(PassTag::Transparent),
+        _ => None,
+    };
+    if db.legacy_layers {
+        raster_all(primitivbuffer, &vbuffpy.buffer3d, &mut db.db, pass);
+    } else {
+        match pass {
+            Some(PassTag::Transparent) => {
+                raster_all(
+                    primitivbuffer,
+                    &vbuffpy.buffer3d,
+                    &mut db.transparent_db,
+                    Some(PassTag::Transparent),
+                );
+            }
+            _ => {
+                raster_all(
+                    primitivbuffer,
+                    &vbuffpy.buffer3d,
+                    &mut db.opaque_db,
+                    Some(PassTag::Opaque),
+                );
+            }
+        }
+    }
 }

--- a/src/raster/mod.rs
+++ b/src/raster/mod.rs
@@ -184,26 +184,22 @@ pub fn raster_all_py(
         Some("transparent") => Some(PassTag::Transparent),
         _ => None,
     };
-    if db.legacy_layers {
-        raster_all(primitivbuffer, &vbuffpy.buffer3d, &mut db.db, pass);
-    } else {
-        match pass {
-            Some(PassTag::Transparent) => {
-                raster_all(
-                    primitivbuffer,
-                    &vbuffpy.buffer3d,
-                    &mut db.transparent_db,
-                    Some(PassTag::Transparent),
-                );
-            }
-            _ => {
-                raster_all(
-                    primitivbuffer,
-                    &vbuffpy.buffer3d,
-                    &mut db.opaque_db,
-                    Some(PassTag::Opaque),
-                );
-            }
+    match pass {
+        Some(PassTag::Transparent) => {
+            raster_all(
+                primitivbuffer,
+                &vbuffpy.buffer3d,
+                &mut db.transparent_db,
+                Some(PassTag::Transparent),
+            );
+        }
+        _ => {
+            raster_all(
+                primitivbuffer,
+                &vbuffpy.buffer3d,
+                &mut db.opaque_db,
+                Some(PassTag::Opaque),
+            );
         }
     }
 }

--- a/src/raster/raster_line.rs
+++ b/src/raster/raster_line.rs
@@ -91,6 +91,7 @@ mod tests {
             material_id: 2,
             node_id: 3,
             primitive_id: 0,
+            transparent: false,
         };
         let pav = Vertex {
             pos: nalgebra_glm::vec4(0.0, 1.0, 1.0, 1.0),
@@ -116,6 +117,7 @@ mod tests {
             material_id: 2,
             node_id: 3,
             primitive_id: 0,
+            transparent: false,
         };
         let pav = Vertex {
             pos: nalgebra_glm::vec4(0.0, 0.0, 1.0, 1.0),

--- a/src/raster/raster_rect.rs
+++ b/src/raster/raster_rect.rs
@@ -118,6 +118,7 @@ mod test_raster_rect {
             material_id: 2,
             node_id: 3,
             primitive_id: 4,
+            transparent: false,
         };
 
         let top_left = Vertex {
@@ -161,6 +162,7 @@ mod test_raster_rect {
             material_id: 2,
             node_id: 3,
             primitive_id: 4,
+            transparent: false,
         };
 
         let top_left = Vertex {

--- a/src/raster/raster_triangle_tomato.rs
+++ b/src/raster/raster_triangle_tomato.rs
@@ -629,6 +629,7 @@ mod test_raster_duo_triangle {
                 material_id: 2,
                 node_id: 3,
                 primitive_id: 0,
+                transparent: false,
             },
         )
     }
@@ -649,6 +650,7 @@ mod test_raster_mono_triangle {
             material_id: 2,
             node_id: 3,
             primitive_id: 0,
+            transparent: false,
         };
 
         let pa = Vertex::new(
@@ -688,6 +690,7 @@ mod test_raster_mono_triangle {
             material_id: 2,
             node_id: 3,
             primitive_id: 0,
+            transparent: false,
         };
 
         let pa = Vertex::new(
@@ -727,6 +730,7 @@ mod test_raster_mono_triangle {
             material_id: 2,
             node_id: 3,
             primitive_id: 0,
+            transparent: false,
         };
 
         let pa = Vertex::new(
@@ -767,6 +771,7 @@ mod test_raster_mono_triangle {
             material_id: 2,
             node_id: 3,
             primitive_id: 0,
+            transparent: false,
         };
 
         let pa = Vertex::new(
@@ -806,6 +811,7 @@ mod test_raster_mono_triangle {
             material_id: 2,
             node_id: 3,
             primitive_id: 0,
+            transparent: false,
         };
 
         let pa = Vertex::new(
@@ -845,6 +851,7 @@ mod test_raster_mono_triangle {
             material_id: 2,
             node_id: 3,
             primitive_id: 0,
+            transparent: false,
         };
 
         let pa = Vertex::new(

--- a/tests/benchs/r_code/test_bench_triangle_raster.py
+++ b/tests/benchs/r_code/test_bench_triangle_raster.py
@@ -14,6 +14,15 @@ def rust_version(primitive_buffer, vertex_buffer, drawing_buffer):
     raster_all_py(primitive_buffer, vertex_buffer, drawing_buffer)
 
 
+def rust_transparent_pass(primitive_buffer, vertex_buffer, drawing_buffer):
+    raster_all_py(
+        primitive_buffer,
+        vertex_buffer,
+        drawing_buffer,
+        pass_filter="transparent",
+    )
+
+
 sizes = [32, 64, 128, 256, 512, 2048, 4096]
 
 
@@ -43,6 +52,35 @@ def test_bench_rust_triangle_raster(benchmark, size):
         )
 
     benchmark(rust_version, primitive_buffer, vertex_buffer, drawing_buffer)
+
+
+@pytest.mark.parametrize("size", [64, 256, 512])
+@pytest.mark.benchmark(group="triangle_raster_transparent_pass")
+def test_bench_rust_triangle_raster_transparent_pass(benchmark, size):
+    drawing_buffer = DrawingBufferPy(256, 256)
+    drawing_buffer.hard_clear(1000)
+
+    primitive_buffer = PrimitiveBufferPy(2000)
+    vertex_buffer = VertexBufferPy(32, 32, 32)
+
+    for i in range(1000):
+        primitive_buffer.add_triangle(
+            102,  # node
+            i,  # geom
+            303,  # material
+            2,  # row col
+            2,
+            1.0,
+            5,  # top
+            size,  # right
+            1.0,
+            6,  # bottom
+            size,  # left
+            1.0,
+            transparent=True,
+        )
+
+    benchmark(rust_transparent_pass, primitive_buffer, vertex_buffer, drawing_buffer)
 
 
 TRI_MODE = ["STACK", "SAME", "BELLOW"]
@@ -114,5 +152,5 @@ def test_bench_rust_triangle_raster_mode(benchmark, mode, tri_count):
                 size,  # left
                 depth,
             )
-    assert (primitive_buffer.primitive_count(), tri_count)
+    assert primitive_buffer.primitive_count() == tri_count
     benchmark(rust_version, primitive_buffer, vertex_buffer, drawing_buffer)

--- a/tests/tt3de/test_r_draw_buffer.py
+++ b/tests/tt3de/test_r_draw_buffer.py
@@ -40,25 +40,9 @@ class Test_DrawBuffer(unittest.TestCase):
 
         layer = 1
         v = gb.get_depth_buffer_cell(0, 0, layer)
-        self.assertEqual(
-            v,
-            {
-                "depth": 10.0,
-                "pix_info": layer,
-                "uv": [0.0, 0.0],
-                "uv_1": [0.0, 0.0],
-                "frag_pos": [0.0, 0.0],
-                "material_id": 0,
-                "geometry_id": 0,
-                "node_id": 0,
-                "primitive_id": 0,
-                "front_facing": True,
-                "line_coord": 0.0,
-                "point_coord": [0.0, 0.0],
-            },
-        )
+        self.assertEqual(v, {})
 
-        for pix_idx in range(10 * 10 * 2):
+        for pix_idx in range(10 * 10):
             self.assertEqual(
                 gb.get_pix_info_element(pix_idx),
                 {
@@ -132,25 +116,9 @@ class Test_DrawBuffer(unittest.TestCase):
 
         layer = 1
         v = drawbuffer.get_depth_buffer_cell(0, 0, layer)
-        self.assertEqual(
-            v,
-            {
-                "depth": 12.0,
-                "pix_info": layer,
-                "uv": [0.0, 0.0],
-                "uv_1": [0.0, 0.0],
-                "frag_pos": [0.0, 0.0],
-                "material_id": 0,
-                "geometry_id": 0,
-                "node_id": 0,
-                "primitive_id": 0,
-                "front_facing": True,
-                "line_coord": 0.0,
-                "point_coord": [0.0, 0.0],
-            },
-        )
+        self.assertEqual(v, {})
 
-        for pix_idx in range(10 * 10 * 2):
+        for pix_idx in range(10 * 10):
             self.assertEqual(
                 drawbuffer.get_pix_info_element(pix_idx),
                 {
@@ -174,7 +142,6 @@ class Test_DrawBuffer(unittest.TestCase):
         self.assertEqual(maxd, 12.0)
 
         mind, maxd = drawbuffer.get_min_max_depth(1)
-
         self.assertEqual(mind, 12.0)
         self.assertEqual(maxd, 12.0)
 
@@ -256,9 +223,8 @@ class Test_DrawBuffer(unittest.TestCase):
 
         drawbuffer.set_depth_content(0, 0, *inpuut_tuple)
 
-        ### since we set depth at 0 0 ; the pixel idx 0 is moved to back
-        ### therefore we "rolled" the buffer and put ourself in the index 1.
-        pix_info1 = drawbuffer.get_pix_info_element(1)
+        # In the canonical single-layer buffer, the winning sample stays at pix index 0.
+        pix_info1 = drawbuffer.get_pix_info_element(0)
         assertPixInfoEqual(
             pix_info1,
             {
@@ -271,28 +237,13 @@ class Test_DrawBuffer(unittest.TestCase):
             },
         )
 
-        # this one is actually the one that was before me :)
-        pix_info0 = drawbuffer.get_pix_info_element(0)
-        assertPixInfoEqual(
-            pix_info0,
-            {
-                "uv": [0.0, 0.0],
-                "uv_1": [0.0, 0.0],
-                "primitive_id": 0,
-                "geometry_id": 0,
-                "node_id": 0,
-                "material_id": 0,
-            },
-        )
-
-        # Layer 0 has changed, and Layer 1 has not;
-        # at layer 0; we have pix_info 1
+        # Layer 0 has changed; layer 1 is not exposed in canonical mode.
         db_return = drawbuffer.get_depth_buffer_cell(0, 0, layer=0)
         self.assertEqual(
             db_return,
             {
                 "depth": 1.0,
-                "pix_info": 1,
+                "pix_info": 0,
                 "uv": [2.0, 3.0],
                 "uv_1": [5.0, 6.0],
                 "frag_pos": _FRAG_POS_NDC_32_R0_C0,
@@ -306,36 +257,21 @@ class Test_DrawBuffer(unittest.TestCase):
             },
         )
 
-        # at layer 1; we have pix_info 0
+        # no legacy layer-1 view in canonical mode
         db_return_layer1 = drawbuffer.get_depth_buffer_cell(0, 0, layer=1)
-        self.assertEqual(
-            db_return_layer1,
-            {
-                "depth": 10.0,
-                "pix_info": 0,
-                "uv": [0.0, 0.0],
-                "uv_1": [0.0, 0.0],
-                "frag_pos": [0.0, 0.0],
-                "primitive_id": 0,
-                "geometry_id": 0,
-                "node_id": 0,
-                "material_id": 0,
-                "front_facing": True,
-                "line_coord": 0.0,
-                "point_coord": [0.0, 0.0],
-            },
-        )
-        mind, maxd = drawbuffer.get_min_max_depth(layer=0)
+        self.assertEqual(db_return_layer1, {})
+        mind, maxd = drawbuffer.get_min_max_depth(0)
 
         self.assertEqual(mind, 1.0)
         self.assertEqual(maxd, 10.0)
 
-        mind, maxd = drawbuffer.get_min_max_depth(layer=1)
-        self.assertEqual(mind, 10.0)
+        mind, maxd = drawbuffer.get_min_max_depth(1)
+        self.assertEqual(mind, 1.0)
         self.assertEqual(maxd, 10.0)
 
     def test_set_depth_content_frag_pos_matches_cell_center_ndc(self):
-        """``frag_pos`` is cell-center NDC (feeds TTSL ``tt_FragPos`` in ``ShaderMaterial``)."""
+        """``frag_pos`` is cell-center NDC (feeds TTSL ``tt_FragPos`` in
+        ``ShaderMaterial``)."""
         w, h = 32, 32
         drawbuffer = DrawingBufferPy(w, h)
         drawbuffer.hard_clear(10.0)
@@ -351,7 +287,7 @@ class Test_DrawBuffer(unittest.TestCase):
             0,
         ]
         drawbuffer.set_depth_content(row, col, *payload)
-        pix = drawbuffer.get_pix_info_element(1)
+        pix = drawbuffer.get_pix_info_element(0)
         half_x = w / 2.0
         half_y = h / 2.0
         sx = 1.0
@@ -378,7 +314,7 @@ class Test_DrawBuffer(unittest.TestCase):
             0,
         ]
         drawbuffer.set_depth_content(row, col, *payload, line_coord=0.375)
-        pix = drawbuffer.get_pix_info_element(1)
+        pix = drawbuffer.get_pix_info_element(0)
         self.assertAlmostEqual(pix["line_coord"], 0.375, places=6)
 
     def test_set_depth_content_point_coord_kwarg(self):
@@ -397,11 +333,11 @@ class Test_DrawBuffer(unittest.TestCase):
         ]
         pc = glm.vec2(0.25, 0.625)
         drawbuffer.set_depth_content(row, col, *payload, point_coord=pc)
-        pix = drawbuffer.get_pix_info_element(1)
+        pix = drawbuffer.get_pix_info_element(0)
         self.assertAlmostEqual(pix["point_coord"][0], 0.25, places=6)
         self.assertAlmostEqual(pix["point_coord"][1], 0.625, places=6)
 
-    def test_set_depth_movelayer_diffent_depth(self):
+    def test_set_depth_overwrites_when_closer(self):
         w, h = 32, 32
         drawbuffer = DrawingBufferPy(w, h)
 
@@ -425,22 +361,20 @@ class Test_DrawBuffer(unittest.TestCase):
             _0_primitiv_id,
         ]
 
-        # we set at 3; this will be in layer 0, 1 is at 10
-        # this will create a roll operation, rolling the pix_info
+        # first set at depth 3
         drawbuffer.set_depth_content(0, 0, *inpuut_tuple_0)
 
-        # we check here the rolling operation
+        # first write lands in layer 0
         db_return0 = drawbuffer.get_depth_buffer_cell(0, 0, layer=0)
-        self.assertEqual(db_return0["pix_info"], 1)
-        db_return1 = drawbuffer.get_depth_buffer_cell(0, 0, layer=1)
-        self.assertEqual(db_return1["pix_info"], 0)
+        self.assertEqual(db_return0["pix_info"], 0)
+        self.assertEqual(drawbuffer.get_depth_buffer_cell(0, 0, layer=1), {})
 
         # and here we check that at layer0; the current tuple values
         self.assertEqual(
             db_return0,
             {
                 "depth": 3.0,
-                "pix_info": 1,
+                "pix_info": 0,
                 "uv": [2.0, 3.0],
                 "uv_1": [5.0, 6.0],
                 "frag_pos": _FRAG_POS_NDC_32_R0_C0,
@@ -471,15 +405,13 @@ class Test_DrawBuffer(unittest.TestCase):
             _1_primitiv_id,
         ]
 
-        # After this, layer 0 is at 1.0 and layer 1 at 3.0;
-        # we operated the rolling operation once more
+        # second write is closer (depth 1), so it replaces layer 0
         drawbuffer.set_depth_content(0, 0, *inpuut_tuple_1)
 
-        # we check here the rolling operation once again,
+        # layer 0 now contains the newer closer value
         db_return0_second = drawbuffer.get_depth_buffer_cell(0, 0, layer=0)
         self.assertEqual(db_return0_second["pix_info"], 0)
-        db_return1_second = drawbuffer.get_depth_buffer_cell(0, 0, layer=1)
-        self.assertEqual(db_return1_second["pix_info"], 1)
+        self.assertEqual(drawbuffer.get_depth_buffer_cell(0, 0, layer=1), {})
 
         # the layer 0 contains the new values; the one
         self.assertEqual(
@@ -500,27 +432,7 @@ class Test_DrawBuffer(unittest.TestCase):
             },
         )
 
-        # the layer 1 contains the bellow this, at depth 3
-        # we just set the value on the layer 1; leaving 0 untouched.
-        self.assertEqual(
-            db_return1_second,
-            {
-                "depth": 3.0,
-                "pix_info": 1,
-                "uv": [2.0, 3.0],
-                "uv_1": [5.0, 6.0],
-                "frag_pos": _FRAG_POS_NDC_32_R0_C0,
-                "primitive_id": _0_primitiv_id,
-                "geometry_id": _0_geom_id,
-                "node_id": _0_node_id,
-                "material_id": _0_material_id,
-                "front_facing": True,
-                "line_coord": 0.0,
-                "point_coord": [0.0, 0.0],
-            },
-        )
-
-    def test_set_depth_different_depth(self):
+    def test_set_depth_keeps_closer_sample(self):
         w, h = 32, 32
         drawbuffer = DrawingBufferPy(w, h)
 
@@ -543,22 +455,20 @@ class Test_DrawBuffer(unittest.TestCase):
             _0_material_id,
             _0_primitiv_id,
         ]
-        # setting at 0,0  the value;
-        # since this is lower than the current layer; this will create a roll operation
+        # first write is closest
         drawbuffer.set_depth_content(0, 0, *inpuut_tuple_0)
 
-        # we check here the rolling operation
+        # layer 0 stores first write
         db_return0 = drawbuffer.get_depth_buffer_cell(0, 0, layer=0)
-        self.assertEqual(db_return0["pix_info"], 1)
-        db_return1 = drawbuffer.get_depth_buffer_cell(0, 0, layer=1)
-        self.assertEqual(db_return1["pix_info"], 0)
+        self.assertEqual(db_return0["pix_info"], 0)
+        self.assertEqual(drawbuffer.get_depth_buffer_cell(0, 0, layer=1), {})
 
         # and here we check that at layer0; the current tuple values
         self.assertEqual(
             db_return0,
             {
                 "depth": 1.0,
-                "pix_info": 1,
+                "pix_info": 0,
                 "uv": [2.0, 3.0],
                 "uv_1": [5.0, 6.0],
                 "frag_pos": _FRAG_POS_NDC_32_R0_C0,
@@ -589,22 +499,20 @@ class Test_DrawBuffer(unittest.TestCase):
             _1_primitiv_id,
         ]
 
-        # We set; but, its after the existing point .
-        # so; there is no rolling operation with the layer0
+        # second write is farther (depth 3), so existing sample remains
         drawbuffer.set_depth_content(0, 0, *inpuut_tuple_1)
 
-        # we check here the rolling operation has not changed since the last insert
+        # layer 0 still points to first write
         db_return0 = drawbuffer.get_depth_buffer_cell(0, 0, layer=0)
-        self.assertEqual(db_return0["pix_info"], 1)
-        db_return1 = drawbuffer.get_depth_buffer_cell(0, 0, layer=1)
-        self.assertEqual(db_return1["pix_info"], 0)
+        self.assertEqual(db_return0["pix_info"], 0)
+        self.assertEqual(drawbuffer.get_depth_buffer_cell(0, 0, layer=1), {})
 
         db_return = drawbuffer.get_depth_buffer_cell(0, 0, layer=0)
         self.assertEqual(
             db_return,
             {
                 "depth": 1.0,
-                "pix_info": 1,
+                "pix_info": 0,
                 "uv": [2.0, 3.0],
                 "uv_1": [5.0, 6.0],
                 "frag_pos": _FRAG_POS_NDC_32_R0_C0,
@@ -618,24 +526,11 @@ class Test_DrawBuffer(unittest.TestCase):
             },
         )
 
-        db_return_layer1 = drawbuffer.get_depth_buffer_cell(0, 0, layer=1)
-        self.assertEqual(
-            db_return_layer1,
-            {
-                "depth": 3.0,
-                "pix_info": 0,
-                "uv": [20.0, 30.0],
-                "uv_1": [50.0, 60.0],
-                "frag_pos": _FRAG_POS_NDC_32_R0_C0,
-                "primitive_id": _1_primitiv_id,
-                "geometry_id": _1_geom_id,
-                "node_id": _1_node_id,
-                "material_id": _1_material_id,
-                "front_facing": True,
-                "line_coord": 0.0,
-                "point_coord": [0.0, 0.0],
-            },
-        )
+        self.assertEqual(drawbuffer.get_depth_buffer_cell(0, 0, layer=1), {})
+
+    def test_constructor_rejects_legacy_layers_kwarg(self):
+        with pytest.raises(TypeError):
+            DrawingBufferPy(8, 8, legacy_layers=True)
 
 
 class Test_totextual(unittest.TestCase):
@@ -727,10 +622,11 @@ class Test_totextual(unittest.TestCase):
         self.assertEqual(len(res[0]), 178)
 
     def test_to_textual_2_glyph_indices_zero_one_two(self) -> None:
-        """GLYPH_STATIC_STR[0], [1], [2] must round-trip through ``to_textual_2``.
+        """
+        GLYPH_STATIC_STR[0], [1], [2] must round-trip through ``to_textual_2``.
 
-        Regression guard for reports that glyph index 0 mis-extracts (e.g. black /
-        wrong segment) after segment-cache reduction.
+        Regression guard for reports that glyph index 0 mis-extracts (e.g. black / wrong
+        segment) after segment-cache reduction.
         """
         gb = DrawingBufferPy(max_row=1, max_col=3)
         gb.hard_clear(100.0)
@@ -784,7 +680,8 @@ class Test_totextual(unittest.TestCase):
         self.assertEqual(seg.style.bgcolor.triplet.blue, 15)
 
     def test_to_textual_2_same_colors_distinct_glyphs_no_wrong_cache_share(self) -> None:
-        """Identical reduced fg/bg must still yield different segments per glyph index."""
+        """Identical reduced fg/bg must still yield different segments per glyph
+        index."""
         gb = DrawingBufferPy(max_row=1, max_col=2, material_parallel_threads=0)
         gb.hard_clear(100.0)
         gb.set_bit_size_front(8, 8, 8)

--- a/tests/tt3de/test_r_fullpass.py
+++ b/tests/tt3de/test_r_fullpass.py
@@ -505,6 +505,7 @@ class Test_PrimitivBuilding(unittest.TestCase):
                 "col": 256,
                 "depth": 1.0,
                 "uv_idx": 0,
+                "transparent": False,
             },
         )
 

--- a/tests/tt3de/test_r_geometry_buffer.py
+++ b/tests/tt3de/test_r_geometry_buffer.py
@@ -78,7 +78,11 @@ class Test_GeometryBuffer(unittest.TestCase):
             elem0,
             {
                 "_type": "Polygon3D",
-                "geom_ref": {"material_id": 202, "node_id": 102},
+                "geom_ref": {
+                    "material_id": 202,
+                    "node_id": 102,
+                    "transparent": False,
+                },
                 "p_start": 0,
                 "triangle_count": 1,
                 "uv_start": 3,
@@ -109,7 +113,11 @@ class Test_GeometryBuffer(unittest.TestCase):
             elem0,
             {
                 "_type": "Polygon2D",
-                "geom_ref": {"material_id": 202, "node_id": 102},
+                "geom_ref": {
+                    "material_id": 202,
+                    "node_id": 102,
+                    "transparent": False,
+                },
                 "p_start": 2,
                 "triangle_count": 23,
                 "uv_start": 32,

--- a/tests/tt3de/ttsl/test_e2e.py
+++ b/tests/tt3de/ttsl/test_e2e.py
@@ -32,6 +32,68 @@ from tt3de.ttsl.compiler import (
 
 
 class Test_EndToEndCompilation(unittest.TestCase):
+    def test_bouncing_clock_shader_and_condition_compiles(self):
+        """
+        Regression: mirrors demos/2d/bouncing_clock.py `clock_tex` where the
+        condition uses boolean `and` between two comparisons.
+        """
+        src = dedent(
+            """
+            def clock_tex(tt_TexCoord0: vec2, tt_TexCoord1: vec2) -> tuple[vec4, vec4, int]:
+                sampled_top: vec4 = tt_texture(u_TextureIndex, tt_TexCoord0)
+                sampled_bottom: vec4 = tt_texture(u_TextureIndex, tt_TexCoord1)
+                if sampled_top.w < 0.5 and sampled_bottom.w < 0.5:
+                    return (vec4(0.0, 0.0, 0.0, 1.0), vec4(0.0, 0.0, 0.0, 1.0), 0)
+                top_rgb: vec4 = vec4(sampled_top.x, sampled_top.y, sampled_top.z, 1.0)
+                bottom_rgb: vec4 = vec4(sampled_bottom.x, sampled_bottom.y, sampled_bottom.z, 1.0)
+                return (top_rgb, bottom_rgb, 0)
+            """
+        )
+        bytecode, reg_settings = all_passes_compilation(
+            src, "clock_tex", {"u_TextureIndex": int}
+        )
+        self.assertIsInstance(bytecode, bytes)
+        self.assertGreater(len(bytecode), 0)
+
+        reg_settings.set_variable("u_TextureIndex", 0)
+        reg_settings.set_variable(PIXELVAR_TT_TEXCOORD0, glm.vec2(0.5, 0.5))
+        reg_settings.set_variable(PIXELVAR_TT_TEXCOORD1, glm.vec2(0.5, 0.5))
+        reg_settings.set_variable(PIXELVAR_TT_FRAGCOORD, glm.vec2(0.0, 0.0))
+        front, back, glyph = ttsl_run(*reg_settings.get_register_list(), bytecode)
+        self.assertEqual(glyph, 0)
+        self.assertEqual(front, back)
+
+    def test_bouncing_clock_shader_branch_assign_then_return_compiles(self):
+        """
+        Regression: mirrors demos/2d/bouncing_clock.py `clock_tex`.
+        A branch with an early return followed by an assignment+return in the
+        fallthrough path previously crashed SSA rename with:
+        "no current version for var 'rgb' when filling phi operand".
+        """
+        src = dedent(
+            """
+            def clock_tex(tt_TexCoord0: vec2) -> tuple[vec4, vec4, int]:
+                sampled: vec4 = tt_texture(u_TextureIndex, tt_TexCoord0)
+                if sampled.w < 0.5:
+                    return (vec4(0.0, 0.0, 0.0, 1.0), vec4(0.0, 0.0, 0.0, 1.0), 0)
+                rgb: vec4 = vec4(sampled.x, sampled.y, sampled.z, 1.0)
+                return (rgb, rgb, 0)
+            """
+        )
+        bytecode, reg_settings = all_passes_compilation(
+            src, "clock_tex", {"u_TextureIndex": int}
+        )
+        self.assertIsInstance(bytecode, bytes)
+        self.assertGreater(len(bytecode), 0)
+
+        reg_settings.set_variable("u_TextureIndex", 0)
+        reg_settings.set_variable(PIXELVAR_TT_TEXCOORD0, glm.vec2(0.5, 0.5))
+        reg_settings.set_variable(PIXELVAR_TT_TEXCOORD1, glm.vec2(0.0, 0.0))
+        reg_settings.set_variable(PIXELVAR_TT_FRAGCOORD, glm.vec2(0.0, 0.0))
+        front, back, glyph = ttsl_run(*reg_settings.get_register_list(), bytecode)
+        self.assertEqual(glyph, 0)
+        self.assertEqual(front, back)
+
     def test_uv_pulse_branching_shader_compiles_to_bytecode(self):
         """
         Regression: if/else with returns on both branches uses builtins (tt_TexCoord0,
@@ -69,9 +131,7 @@ class Test_EndToEndCompilation(unittest.TestCase):
         reg_settings.set_variable(PIXELVAR_TT_FRAGCOORD, glm.vec2(10.0, 20.0))
 
     def test_ttsl_square_demo_shader_compiles_to_bytecode(self):
-        """
-        Mirrors demos/2d/ttsl_square.py shader source.
-        """
+        """Mirrors demos/2d/ttsl_square.py shader source."""
         src = dedent(
             """
             def my_shader(tt_TexCoord0: vec2) -> tuple[vec4, vec4, int]:
@@ -98,11 +158,10 @@ class Test_EndToEndCompilation(unittest.TestCase):
         reg_settings.set_variable(PIXELVAR_TT_FRAGCOORD, glm.vec2(12.0, 8.0))
 
     def test_ttsl_square_demo_shader_time_changes_pixels_material_apply(self):
-        """
-        Same shader as ``demos/2d/ttsl_square.py``: compiled bytecode plus constant seed
-        registers, ``MaterialBufferPy.set_shader_time``, then sequential and parallel
-        ``apply_material_*`` must reflect changing ``tt_Time`` in the raster output.
-        """
+        """Same shader as ``demos/2d/ttsl_square.py``: compiled bytecode plus constant
+        seed registers, ``MaterialBufferPy.set_shader_time``, then sequential and
+        parallel ``apply_material_*`` must reflect changing ``tt_Time`` in the raster
+        output."""
         src = dedent(
             """
             def my_shader(tt_TexCoord0: vec2) -> tuple[vec4, vec4, int]:
@@ -169,7 +228,8 @@ class Test_EndToEndCompilation(unittest.TestCase):
         )
 
     def test_tt_texture_shader_samples_bound_texture(self):
-        """Bytecode ``tt_texture`` must read the live ``TextureBuffer`` during apply_material."""
+        """Bytecode ``tt_texture`` must read the live ``TextureBuffer`` during
+        apply_material."""
         src = dedent(
             """
             def shade(tt_TexCoord0: vec2) -> tuple[vec4, vec4, int]:
@@ -311,7 +371,8 @@ class Test_EndToEndCompilation(unittest.TestCase):
             self.assertEqual(glyph, 0, msg=f"glyph should be 0 at ndc={ndc}")
 
     def test_depth_fog_glyph_shader_vm_vs_python_reference(self):
-        """Mirror ``depth_fog_glyph`` (demos fog + quantized glyph bands): VM vs Python.
+        """
+        Mirror ``depth_fog_glyph`` (demos fog + quantized glyph bands): VM vs Python.
 
         Regression: cascading ``if cond: return ...`` (no ``else``) used to flow
         through every conditional and run the final return because
@@ -432,7 +493,8 @@ class Test_EndToEndCompilation(unittest.TestCase):
             )
 
     def test_user_uniforms_vec3_vec2_ttsl_run(self):
-        """User globals from globals_dict occupy VM registers; seed via RegisterSettings."""
+        """User globals from globals_dict occupy VM registers; seed via
+        RegisterSettings."""
         src = dedent(
             """
             def shade(tt_FragCoord: vec2) -> tuple[vec4, vec4, int]:
@@ -590,7 +652,7 @@ class Test_FloorCeilFractMod(unittest.TestCase):
         self.assertAlmostEqual(front.x, expected, places=4)
 
     def test_floor_with_variable_input(self):
-        """floor applied to a runtime uniform, not just a compile-time constant."""
+        """Floor applied to a runtime uniform, not just a compile-time constant."""
         src = dedent(
             """
             def shade(tt_FragCoord: vec2) -> tuple[vec4, vec4, int]:
@@ -611,7 +673,7 @@ class Test_FloorCeilFractMod(unittest.TestCase):
             )
 
     def test_mod_with_variable_wrapping(self):
-        """mod wraps a computed index back into [0, 4) — the fog-band use case."""
+        """Mod wraps a computed index back into [0, 4) — the fog-band use case."""
         src = dedent(
             """
             def shade(tt_FragCoord: vec2) -> tuple[vec4, vec4, int]:
@@ -661,7 +723,7 @@ class Test_Normalize(unittest.TestCase):
     """End-to-end tests for normalize builtin."""
 
     def test_normalize_v3_happy_path(self):
-        """normalize(vec3) returns unit-length vector."""
+        """Normalize(vec3) returns unit-length vector."""
         src = dedent(
             """
             def shade(tt_FragCoord: vec2) -> tuple[vec4, vec4, int]:
@@ -677,7 +739,7 @@ class Test_Normalize(unittest.TestCase):
         self.assertAlmostEqual(front.z, 0.0, places=5)
 
     def test_normalize_v3_non_unit(self):
-        """normalize of a non-unit vector yields a unit vector."""
+        """Normalize of a non-unit vector yields a unit vector."""
         src = dedent(
             """
             def shade(tt_FragCoord: vec2) -> tuple[vec4, vec4, int]:
@@ -695,7 +757,7 @@ class Test_Normalize(unittest.TestCase):
         self.assertAlmostEqual(front.z, expected.z, places=5)
 
     def test_normalize_v3_zero_vector(self):
-        """normalize(zero) returns zero vector (guarded in Rust VM)."""
+        """Normalize(zero) returns zero vector (guarded in Rust VM)."""
         src = dedent(
             """
             def shade(tt_FragCoord: vec2) -> tuple[vec4, vec4, int]:
@@ -711,7 +773,7 @@ class Test_Normalize(unittest.TestCase):
         self.assertAlmostEqual(front.z, 0.0, places=5)
 
     def test_normalize_v2(self):
-        """normalize(vec2) works."""
+        """Normalize(vec2) works."""
         src = dedent(
             """
             def shade(tt_FragCoord: vec2) -> tuple[vec4, vec4, int]:
@@ -727,7 +789,7 @@ class Test_Normalize(unittest.TestCase):
         self.assertAlmostEqual(front.y, expected.y, places=5)
 
     def test_normalize_v4(self):
-        """normalize(vec4) works."""
+        """Normalize(vec4) works."""
         src = dedent(
             """
             def shade(tt_FragCoord: vec2) -> tuple[vec4, vec4, int]:
@@ -744,7 +806,7 @@ class Test_Normalize(unittest.TestCase):
         self.assertAlmostEqual(front.z, expected.z, places=5)
 
     def test_normalize_with_variable_input(self):
-        """normalize works with runtime (non-constant) inputs."""
+        """Normalize works with runtime (non-constant) inputs."""
         src = dedent(
             """
             def shade(tt_FragCoord: vec2) -> tuple[vec4, vec4, int]:
@@ -782,7 +844,7 @@ class Test_Dot(unittest.TestCase):
     """End-to-end tests for dot builtin."""
 
     def test_dot_v3_orthogonal(self):
-        """dot(orthogonal vectors) = 0."""
+        """Dot(orthogonal vectors) = 0."""
         src = dedent(
             """
             def shade(tt_FragCoord: vec2) -> tuple[vec4, vec4, int]:
@@ -797,7 +859,7 @@ class Test_Dot(unittest.TestCase):
         self.assertAlmostEqual(front.x, 0.0, places=5)
 
     def test_dot_v3_parallel(self):
-        """dot(parallel unit vectors) = 1."""
+        """Dot(parallel unit vectors) = 1."""
         src = dedent(
             """
             def shade(tt_FragCoord: vec2) -> tuple[vec4, vec4, int]:
@@ -812,7 +874,7 @@ class Test_Dot(unittest.TestCase):
         self.assertAlmostEqual(front.x, 1.0, places=5)
 
     def test_dot_v3_opposite(self):
-        """dot(opposite unit vectors) = -1."""
+        """Dot(opposite unit vectors) = -1."""
         src = dedent(
             """
             def shade(tt_FragCoord: vec2) -> tuple[vec4, vec4, int]:
@@ -827,7 +889,7 @@ class Test_Dot(unittest.TestCase):
         self.assertAlmostEqual(front.x, -1.0, places=5)
 
     def test_dot_v2(self):
-        """dot(vec2, vec2) works."""
+        """Dot(vec2, vec2) works."""
         src = dedent(
             """
             def shade(tt_FragCoord: vec2) -> tuple[vec4, vec4, int]:
@@ -843,7 +905,7 @@ class Test_Dot(unittest.TestCase):
         self.assertAlmostEqual(front.x, expected, places=5)
 
     def test_dot_v4(self):
-        """dot(vec4, vec4) works."""
+        """Dot(vec4, vec4) works."""
         src = dedent(
             """
             def shade(tt_FragCoord: vec2) -> tuple[vec4, vec4, int]:
@@ -859,7 +921,7 @@ class Test_Dot(unittest.TestCase):
         self.assertAlmostEqual(front.x, expected, places=5)
 
     def test_dot_with_variable_input(self):
-        """dot works with runtime (non-constant) vectors."""
+        """Dot works with runtime (non-constant) vectors."""
         src = dedent(
             """
             def shade(tt_FragCoord: vec2) -> tuple[vec4, vec4, int]:
@@ -895,7 +957,7 @@ class Test_Length(unittest.TestCase):
     """End-to-end tests for length builtin."""
 
     def test_length_v3_unit(self):
-        """length(unit vector) = 1."""
+        """Length(unit vector) = 1."""
         src = dedent("""
         def shade(tt_FragCoord: vec2) -> tuple[vec4, vec4, int]:
             v: vec3 = vec3(1.0, 0.0, 0.0)
@@ -907,7 +969,7 @@ class Test_Length(unittest.TestCase):
         self.assertAlmostEqual(front.x, 1.0, places=5)
 
     def test_length_v3_zero(self):
-        """length(zero) = 0."""
+        """Length(zero) = 0."""
         src = dedent("""
         def shade(tt_FragCoord: vec2) -> tuple[vec4, vec4, int]:
             v: vec3 = vec3(0.0, 0.0, 0.0)
@@ -919,7 +981,7 @@ class Test_Length(unittest.TestCase):
         self.assertAlmostEqual(front.x, 0.0, places=5)
 
     def test_length_v2_v4(self):
-        """length(vec2) and length(vec4)."""
+        """Length(vec2) and length(vec4)."""
         src = dedent("""
         def shade(tt_FragCoord: vec2) -> tuple[vec4, vec4, int]:
             v2: vec2 = vec2(3.0, 4.0)
@@ -958,7 +1020,7 @@ class Test_Max(unittest.TestCase):
         self.assertAlmostEqual(front.x, 7.0, places=5)
 
     def test_max_f32_negative(self):
-        """max with negative values."""
+        """Max with negative values."""
         src = dedent("""
         def shade(tt_FragCoord: vec2) -> tuple[vec4, vec4, int]:
             m: float = max(-2.0, -5.0)
@@ -969,7 +1031,7 @@ class Test_Max(unittest.TestCase):
         self.assertAlmostEqual(front.x, -2.0, places=5)
 
     def test_max_vec3(self):
-        """max(vec3, vec3) component-wise."""
+        """Max(vec3, vec3) component-wise."""
         src = dedent("""
         def shade(tt_FragCoord: vec2) -> tuple[vec4, vec4, int]:
             a: vec3 = vec3(1.0, 5.0, 3.0)
@@ -1028,7 +1090,7 @@ class Test_Clamp(unittest.TestCase):
         self.assertAlmostEqual(front.x, 1.0, places=5)
 
     def test_clamp_vec3(self):
-        """clamp(vec3, vec3, vec3) component-wise."""
+        """Clamp(vec3, vec3, vec3) component-wise."""
         src = dedent("""
         def shade(tt_FragCoord: vec2) -> tuple[vec4, vec4, int]:
             x: vec3 = vec3(-0.5, 0.5, 1.5)


### PR DESCRIPTION
## Summary

Removes the \legacy_layers\ compatibility path so rendering always uses the opaque pass, transparent pass, and front-color compositing with blend modes.

## Changes

- **Rust**: \src/drawbuffer\ (including new \lend.rs\), raster, primitive building/buffer, materials, and geombuffer updates aligned with the two-pass pipeline.
- **Python**: \ender_context_rust.py\, \	t_2dnodes.py\, \	t_3dnodes.py\ bindings updated for the new behavior.
- **Docs**: \source/high_level_api.rst\ and \source/low_level_api.rst\ updated.
- **Tests**: geometry buffer and full-pass tests adjusted.
- **Evolution**: adds \.evolution/evol-remove-legacy-layers.md\ documenting the migration.
- **Chore**: \pyproject.toml\ key ordering normalized by repo pre-commit hooks.

## Verification

- \cargo check --all-targets\ passes locally.

Made with [Cursor](https://cursor.com)