### PR TITLE
fix: correct repeating UV wrap for custom textures

### DIFF
--- a/src/texturebuffer/mod.rs
+++ b/src/texturebuffer/mod.rs
@@ -184,12 +184,14 @@ impl<const SIZE: usize> TextureCustom<SIZE> {
 
     pub fn uv_map_inline(&self, u: f32, v: f32) -> RGBA {
         let u_val = if self.repeat_x {
-            u % 1.0
+            // Keep wrapped UVs in [0,1) so negative tiled UVs sample correctly.
+            u.rem_euclid(1.0)
         } else {
             u.clamp(0.0, 1.0)
         };
         let v_val = if self.repeat_y {
-            v % 1.0
+            // Keep wrapped UVs in [0,1) so negative tiled UVs sample correctly.
+            v.rem_euclid(1.0)
         } else {
             v.clamp(0.0, 1.0)
         };

--- a/tests/tt3de/test_r_texture_buffer.py
+++ b/tests/tt3de/test_r_texture_buffer.py
@@ -77,3 +77,27 @@ class Test_TextureArray(unittest.TestCase):
             texture_array.get_rgba_at(0, 0.4, 0.4),
             texture_array.get_rgba_at(0, 1.4, 1.4),
         )
+
+    def test_mapping_repeat_negative_uv_custom_texture(self):
+        texture_array = TextureBufferPy(12)
+        self.assertEqual(texture_array.size(), 0)
+        sky1: ImageTexture = fast_load("models/sky1.bmp")
+
+        texture_array.add_texture(
+            sky1.image_width,
+            sky1.image_height,
+            sky1.chained_data(),
+            repeat_width=True,
+            repeat_height=True,
+        )
+        self.assertEqual(texture_array.size(), 1)
+        self.assertEqual(texture_array.get_wh_of(0), (256, 114))
+
+        self.assertEqual(
+            texture_array.get_rgba_at(0, 0.25, 0.75),
+            texture_array.get_rgba_at(0, -0.75, -0.25),
+        )
+        self.assertEqual(
+            texture_array.get_rgba_at(0, 0.25, 0.75),
+            texture_array.get_rgba_at(0, -1.75, -2.25),
+        )


### PR DESCRIPTION
Use Euclidean wrapping for repeating custom textures so negative OBJ UVs tile correctly instead of sampling stretched edge texels. Add regression coverage for equivalent positive and negative wrapped coordinates.