### PR TITLE
feat: extract low-poly UV sphere into Prefab3D.latlong_uv_sphere

### DIFF
--- a/demos/3d/ttsl_normal_viewpos.py
+++ b/demos/3d/ttsl_normal_viewpos.py
@@ -14,7 +14,6 @@ Run:
     uv run python demos/3d/ttsl_normal_viewpos.py
 """
 
-import math
 from textwrap import dedent
 
 from pyglm import glm
@@ -22,10 +21,10 @@ from textual.app import App, ComposeResult
 from textual.widgets import Header
 
 from tt3de.glm_camera import ViewportScaleMode
-from tt3de.points import Point2D, Point3D
+from tt3de.prefab3d import Prefab3D
 from tt3de.textual_standalone import TT3DViewStandAlone
 from tt3de.tt3de import find_glyph_indices_py, materials  # type: ignore[reportMissingImports]
-from tt3de.tt_3dnodes import TT3DPolygon, TT3DNode
+from tt3de.tt_3dnodes import TT3DNode
 from tt3de.ttsl.compiler import RegisterSettings, all_passes_compilation
 
 CAM_NEAR = 0.1
@@ -86,48 +85,6 @@ SHADER_SPHERE_GLYPHS_SRC = dedent(
         return (fr, bg, u_g_hash)
     """
 )
-
-
-def _low_poly_uv_sphere(radius: float, stacks: int, slices: int) -> TT3DPolygon:
-    """Faceted sphere: each triangle has a single flat normal (typical engine path)."""
-    if stacks < 1 or slices < 3:
-        raise ValueError("stacks must be >= 1 and slices >= 3")
-    verts: list[Point3D] = []
-    for stack in range(stacks + 1):
-        v = stack / stacks
-        theta = v * math.pi
-        st = math.sin(theta)
-        ct = math.cos(theta)
-        for sl in range(slices + 1):
-            u = sl / slices
-            phi = u * 2.0 * math.pi
-            x = radius * st * math.cos(phi)
-            y = radius * ct
-            z = radius * st * math.sin(phi)
-            verts.append(Point3D(x, y, z))
-
-    tris: list[tuple[int, int, int]] = []
-    uvs: list[tuple[Point2D, Point2D, Point2D]] = []
-    for stack in range(stacks):
-        for sl in range(slices):
-            i0 = stack * (slices + 1) + sl
-            i1 = stack * (slices + 1) + sl + 1
-            i2 = (stack + 1) * (slices + 1) + sl
-            i3 = (stack + 1) * (slices + 1) + sl + 1
-            ua = Point2D(sl / slices, stack / stacks)
-            ub = Point2D((sl + 1) / slices, stack / stacks)
-            uc = Point2D(sl / slices, (stack + 1) / stacks)
-            ud = Point2D((sl + 1) / slices, (stack + 1) / stacks)
-            tris.append((i0, i2, i1))
-            uvs.append((ua, uc, ub))
-            tris.append((i1, i2, i3))
-            uvs.append((ub, uc, ud))
-
-    m = TT3DPolygon()
-    m.vertex_list = verts
-    m.triangles = tris
-    m.uvmap = uvs
-    return m
 
 
 def _add_sphere_material(
@@ -221,13 +178,13 @@ class TTSLNormalViewPosDemo(TT3DViewStandAlone):
 
         self.spin_root = TT3DNode()
 
-        sphere = _low_poly_uv_sphere(0.42, stacks=4, slices=10)
+        sphere = Prefab3D.latlong_uv_sphere(0.42, stacks=4, slices=10)
         sphere.material_id = mat_sphere
         sphere.local_transform = glm.translate(glm.vec3(-1.05, 0.0, 0.0))
         self.spin_root.add_child(sphere)
 
         # Second mesh: same low-poly sphere with ``sphere_glyphs`` TTSL.
-        glyph_sphere = _low_poly_uv_sphere(0.5, stacks=6, slices=12)
+        glyph_sphere = Prefab3D.latlong_uv_sphere(0.5, stacks=6, slices=12)
         glyph_sphere.material_id = mat_glyphs
         glyph_sphere.local_transform = glm.translate(glm.vec3(1.05, 0.0, 0.0))
         self.spin_root.add_child(glyph_sphere)

--- a/python/tt3de/prefab3d.py
+++ b/python/tt3de/prefab3d.py
@@ -126,6 +126,64 @@ class Prefab3D:
         return m
 
     @staticmethod
+    def latlong_uv_sphere(
+        radius: float = 1.0, stacks: int = 4, slices: int = 10
+    ) -> TT3DPolygon:
+        """Faceted UV-mapped sphere via latitude–longitude tessellation.
+
+        Each triangle carries a single **flat (faceted) normal** — the mesh is
+        appropriate for ``tt_Normal`` lighting demos where per-face normals are
+        expected, not smooth per-vertex interpolation.
+
+        **Axis convention**: Y-up, poles on ±Y.  **UV range**: [0, 1] on each
+        triangle, laid out as a lat-long strip (U wraps horizontally, V from
+        bottom to top pole).
+
+        ``stacks`` must be >= 1 and ``slices`` >= 3.
+
+        Returns a ``TT3DPolygon`` with ``(stacks + 1) * (slices + 1)`` vertices
+        and ``2 * stacks * slices`` triangles.
+        """
+        if stacks < 1 or slices < 3:
+            raise ValueError("stacks must be >= 1 and slices >= 3")
+        verts: list[Point3D] = []
+        for stack in range(stacks + 1):
+            v = stack / stacks
+            theta = v * math.pi
+            st = math.sin(theta)
+            ct = math.cos(theta)
+            for sl in range(slices + 1):
+                u = sl / slices
+                phi = u * 2.0 * math.pi
+                x = radius * st * math.cos(phi)
+                y = radius * ct
+                z = radius * st * math.sin(phi)
+                verts.append(Point3D(x, y, z))
+
+        tris: list[tuple[int, int, int]] = []
+        uvs: list[tuple[Point2D, Point2D, Point2D]] = []
+        for stack in range(stacks):
+            for sl in range(slices):
+                i0 = stack * (slices + 1) + sl
+                i1 = stack * (slices + 1) + sl + 1
+                i2 = (stack + 1) * (slices + 1) + sl
+                i3 = (stack + 1) * (slices + 1) + sl + 1
+                ua = Point2D(sl / slices, stack / stacks)
+                ub = Point2D((sl + 1) / slices, stack / stacks)
+                uc = Point2D(sl / slices, (stack + 1) / stacks)
+                ud = Point2D((sl + 1) / slices, (stack + 1) / stacks)
+                tris.append((i0, i2, i1))
+                uvs.append((ua, uc, ub))
+                tris.append((i1, i2, i3))
+                uvs.append((ub, uc, ud))
+
+        m = TT3DPolygon()
+        m.vertex_list = verts
+        m.triangles = tris
+        m.uvmap = uvs
+        return m
+
+    @staticmethod
     def unitary_circle(segment_count=3) -> TT3DPolygon:
         vertices = [Point3D(0.0, 0.0, 0.0)]
         triangles = []

--- a/source/high_level_api.rst
+++ b/source/high_level_api.rst
@@ -251,7 +251,7 @@ Core classes
 ^^^^^^^^^^^^
 
 - ``TT3DNode``: 3D scene graph container
-- ``Prefab3D``: helper constructors for test geometry (triangle, square, gizmos, circle)
+- ``Prefab3D``: helper constructors for test geometry (triangle, square, gizmos, circle, cube, lat-long sphere)
 - ``fast_load(...)``: loads meshes/textures from files
 
 Adding primitive meshes
@@ -273,6 +273,22 @@ Adding primitive meshes
             tri.local_transform = glm.translate(glm.vec3(0.0, 1.0, 0.0))
             root.add_child(tri)
             self.rc.append_root(root)
+
+Lat-long UV sphere
+^^^^^^^^^^^^^^^^^^
+
+``Prefab3D.latlong_uv_sphere(radius=1.0, stacks=4, slices=10)`` returns a
+faceted (flat-shaded) ``TT3DPolygon`` with a latitude–longitude tessellation
+and per-triangle UVs in [0, 1].  Y-up, poles on ±Y.  Useful for ``tt_Normal``
+lighting demos where per-face normals are expected.
+
+.. code-block:: python
+
+    from tt3de.prefab3d import Prefab3D
+
+    sphere = Prefab3D.latlong_uv_sphere(0.5, stacks=6, slices=12)
+    sphere.material_id = shader_mat_id
+    root.add_child(sphere)
 
 Loading models
 ^^^^^^^^^^^^^^

--- a/tests/tt3de/test_prefab3d.py
+++ b/tests/tt3de/test_prefab3d.py
@@ -1,0 +1,91 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for ``Prefab3D`` factory methods."""
+
+import math
+import unittest
+
+from tt3de.prefab3d import Prefab3D
+
+
+class TestLatLongUVSphere(unittest.TestCase):
+    def test_default_radius_is_one(self):
+        sphere = Prefab3D.latlong_uv_sphere()
+        for v in sphere.vertex_list:
+            dist = math.sqrt(v.x**2 + v.y**2 + v.z**2)
+            self.assertAlmostEqual(dist, 1.0, places=6)
+
+    def test_custom_radius(self):
+        sphere = Prefab3D.latlong_uv_sphere(radius=2.5, stacks=3, slices=5)
+        for v in sphere.vertex_list:
+            dist = math.sqrt(v.x**2 + v.y**2 + v.z**2)
+            self.assertAlmostEqual(dist, 2.5, places=6)
+
+    def test_vertex_count(self):
+        sphere = Prefab3D.latlong_uv_sphere(stacks=4, slices=10)
+        expected = (4 + 1) * (10 + 1)
+        self.assertEqual(len(sphere.vertex_list), expected)
+
+    def test_triangle_count(self):
+        sphere = Prefab3D.latlong_uv_sphere(stacks=4, slices=10)
+        expected = 2 * 4 * 10
+        self.assertEqual(len(sphere.triangles), expected)
+
+    def test_uvmap_matches_triangles(self):
+        sphere = Prefab3D.latlong_uv_sphere(stacks=3, slices=6)
+        self.assertEqual(len(sphere.uvmap), len(sphere.triangles))
+
+    def test_poles_are_single_points(self):
+        """Top and bottom rings should degenerate to single points at ±Y."""
+        sphere = Prefab3D.latlong_uv_sphere(radius=1.0, stacks=4, slices=8)
+        verts = sphere.vertex_list
+        slices_plus_one = 8 + 1
+        # Top ring (stack 0): all vertices should be at (0, radius, 0)
+        top_ring = verts[:slices_plus_one]
+        for v in top_ring:
+            self.assertAlmostEqual(v.x, 0.0, places=10)
+            self.assertAlmostEqual(v.y, 1.0, places=10)
+            self.assertAlmostEqual(v.z, 0.0, places=10)
+        # Bottom ring (last stack): all vertices should be at (0, -radius, 0)
+        bottom_ring = verts[-slices_plus_one:]
+        for v in bottom_ring:
+            self.assertAlmostEqual(v.x, 0.0, places=10)
+            self.assertAlmostEqual(v.y, -1.0, places=10)
+            self.assertAlmostEqual(v.z, 0.0, places=10)
+
+    def test_minimal_stacks_and_slices(self):
+        sphere = Prefab3D.latlong_uv_sphere(stacks=1, slices=3)
+        self.assertEqual(len(sphere.vertex_list), (1 + 1) * (3 + 1))
+        self.assertEqual(len(sphere.triangles), 2 * 1 * 3)
+
+    def test_stacks_too_low_raises(self):
+        with self.assertRaises(ValueError):
+            Prefab3D.latlong_uv_sphere(stacks=0, slices=3)
+
+    def test_slices_too_low_raises(self):
+        with self.assertRaises(ValueError):
+            Prefab3D.latlong_uv_sphere(stacks=1, slices=2)
+
+    def test_uv_range(self):
+        """All UV coordinates should be in [0, 1]."""
+        sphere = Prefab3D.latlong_uv_sphere(stacks=5, slices=12)
+        for uva, uvb, uvc in sphere.uvmap:
+            for uv in (uva, uvb, uvc):
+                self.assertGreaterEqual(uv.x, 0.0)
+                self.assertLessEqual(uv.x, 1.0)
+                self.assertGreaterEqual(uv.y, 0.0)
+                self.assertLessEqual(uv.y, 1.0)
+
+    def test_triangle_indices_in_range(self):
+        sphere = Prefab3D.latlong_uv_sphere(stacks=4, slices=10)
+        n_verts = len(sphere.vertex_list)
+        for a, b, c in sphere.triangles:
+            self.assertLess(a, n_verts)
+            self.assertLess(b, n_verts)
+            self.assertLess(c, n_verts)
+            self.assertGreaterEqual(a, 0)
+            self.assertGreaterEqual(b, 0)
+            self.assertGreaterEqual(c, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Move _low_poly_uv_sphere from demos/3d/ttsl_normal_viewpos.py into Prefab3D as a reusable static factory. Refactor the demo to use the shared API, add docs and 11 unit tests covering vertex/triangle counts, radius, UV range, pole degeneracy, and input validation.