### PR TITLE
docs: refine evolution for engine profiling benchmarks

### DIFF
--- a/.evolution/draft/evol-engine-profiling-benchmarks.md
+++ b/.evolution/draft/evol-engine-profiling-benchmarks.md
@@ -1,62 +1,77 @@
-# Evolution: Engine profiling benchmark suite (local / optional CI)
+# Evolution: Engine profiling benchmark suite (relocated, consolidated scripts)
 
 ```yaml
 id: evol-engine-profiling-benchmarks
 created: 2026-05-16
+updated: 2026-05-19
 authors: []
 supersedes: []
 superseded-by: ""
 related:
   - scripts/bench_material.sh
+  - scripts/bench_to_textual.sh
   - scripts/dev_material_bench_report.py
-  - tests/benchs/r_code/test_bench_r_pix_shader.py
-  - tests/benchs/r_code/conftest.py
-  - tests/benchs/r_code/test_bench_triangle_raster.py
-  - tests/benchs/r_code/test_bench_to_textual.py
-  - tests/benchs/ttsl/test_bench_ttsl.py
+  - scripts/enrich_benchmark_json.py
+  - tests/benchs/
+  - benches/
   - .github/workflows/fast-checks.yml
   - AGENTS.md
+  - README.md
 ```
 
 ## Summary
 
-Grow a **small, repeatable set of performance benchmarks** for tt3de’s CPU rasterization and Python/Rust boundaries, using the same ergonomics as today’s **material shading** path: `pytest-benchmark` tests, optional **`--benchmark-json`** export, and a **terminal-friendly Rich summary** (narrow tables, sorted means) for humans comparing runs. **Default CI** stays fast via a **`slow_benchmark` pytest marker**: the fast job runs `pytest -m "not slow_benchmark"`; heavy benchmarks are tagged and run locally (or in an optional manual/scheduled workflow), not on every PR.
+Reorganize **existing** engine performance benchmarks so they are **outside the pytest test tree**, invoked only through a **small set of bash scripts** (`scripts/bench_*.sh`), and always end with **human-readable terminal output** (Rich tables, same spirit as `bench_material.sh` + `dev_material_bench_report.py`). Remove PowerShell bench wrappers; document how to run benchmarks in **`AGENTS.md`** and **`README.md`**. **Default CI** (`uv run pytest`) no longer collects or runs long `pytest-benchmark` work—no new benchmark scenarios and no changes to inner timing loops (`FRAME_LOOPS`, parametrization grids, etc.) beyond path and wiring updates.
 
 ## Motivation and context
 
-- **Current behavior** — Several benchmarks already live under `tests/benchs/`:
-  - **Material / per-pixel path**: `tests/benchs/r_code/test_bench_r_pix_shader.py` (`test_bench_material_apply`), with compact pytest table settings in `tests/benchs/r_code/conftest.py`.
-  - **Triangle raster**: `test_bench_triangle_raster.py` (multiple sizes and passes).
-  - **Textual integration**: `test_bench_to_textual.py`.
-  - **TTSL VM**: `tests/benchs/ttsl/test_bench_ttsl.py` (`ttsl_run` group).
-  The script `scripts/bench_material.sh` runs one focused pytest node with `--benchmark-only`, writes JSON under `benchmarks/`, and pipes it through `scripts/dev_material_bench_report.py` for a **readable KPI layout** (~100-column terminals).
+- **Current behavior** — Benchmarks live under `tests/benchs/` and are discovered by normal `uv run pytest` in `.github/workflows/fast-checks.yml`. Two bash entry points exist (`scripts/bench_material.sh`, `scripts/bench_to_textual.sh`); material also has `scripts/bench_material.ps1`. Material benches get a **Rich KPI report**; `bench_to_textual.sh` writes JSON and runs `enrich_benchmark_json.py` but does **not** print a compact summary table. Other modules (`test_bench_triangle_raster.py`, `test_bench_ttsl.py`) are only runnable via manual pytest paths.
 
-- **Problem** — There is **one polished “bench story”** (material) with a dedicated shell entry point and Rich post-processing. Other hotspots (raster, end-to-end frame, compile vs execute, buffer churn) are less uniformly documented and lack the same **one-command + comparable table** workflow. Separately, **`.github/workflows/fast-checks.yml`** runs `uv run pytest` with **no benchmark-specific flags**, so the full tree including `tests/benchs/` is collected whenever those paths match default discovery—benchmarks therefore participate in **standard CI** today unless individual tests are very fast or externally skipped.
+- **Problem** — Mixing long-running benchmarks into `tests/` couples perf work to CI and unit-test mental models. Multiple partial scripts and one `.ps1` duplicate the “how do I bench?” story. Raw JSON under `benchmarks/` is not enough for quick local comparisons unless you already know which report script to run.
 
-- **Fit with tt3de** — The engine is **CPU-only** and targets **small scenes** (`source/index.rst`). Benchmarks should stress **representative** sizes (several canvas widths, modest triangle counts) and label units clearly (per batch vs per frame), not pretend to be GPU-style megascene tests.
+- **Fit with tt3de** — CPU-only, small-scene engine (`source/index.rst`). Benchmarks stay **representative** of today’s parametrization; this evolution is **packaging and ergonomics**, not new coverage.
 
-- **Reasoning** — Reuse **pytest-benchmark** (already in dev dependencies) and the **JSON → Rich report** pattern rather than inventing a second timing harness. Keep **Rust `cargo bench`** / Criterion as a separate axis where micro-Rust slices need nanosecond stability; this evolution focuses on **Python-visible** and **mixed Rust/Python** paths.
+- **Reasoning** — **Relocating** benches out of `tests/` is simpler and more reliable than a `slow_benchmark` marker: CI needs no marker discipline, and `pytest` stays a correctness suite. Reuse **pytest-benchmark** + JSON export; consolidate **bash-only** drivers and **shared Rich reporting**. Rust **Criterion** benches under `benches/` remain a separate, documented axis.
 
 ## Goals
 
-- **Parity scripts** — Add `scripts/bench_*.sh` (or cross-platform `pwsh` companions where the repo already documents Windows flows) for the **highest-value** engine slices, mirroring `bench_material.sh`: `uv run pytest … --benchmark-only`, JSON under `benchmarks/`, then a report command.
-- **Report reuse** — Either **generalize** `dev_material_bench_report.py` to accept benchmark group names / titles, or add **small sibling scripts** per suite that share table/bar helpers—whichever keeps diffs readable.
-- **Coverage map** — Document (in `AGENTS.md` and/or `source/` testing notes) which script measures **what** (material apply, opaque raster, transparent pass, full raster+material loop if feasible, TTSL compile vs `ttsl_run`, Textual widget tick).
-- **CI policy** — Register a **`slow_benchmark`** marker in `pyproject.toml` (`[tool.pytest.ini_options]`). Tag every heavy `pytest-benchmark` test (or module) with `@pytest.mark.slow_benchmark`. **Fast CI** (`fast-checks.yml`): `uv run pytest -m "not slow_benchmark"`. **Local / optional CI**: full suite with `pytest` (no marker filter) or `pytest -m slow_benchmark --benchmark-only` for perf-only runs. Document both commands in `AGENTS.md`. Optional second workflow job or `workflow_dispatch` can run the marked suite with JSON artifacts.
-- **Stable knobs** — Where threading or pool sizes matter (as in material parallel passes), keep **explicit parametrization** and stable `FRAME_LOOPS` / warmup commentary so results are comparable across machines (still **hypotheses**, not release gates).
+- **Relocate benchmarks** — Move `tests/benchs/**` to a top-level tree (proposed: `benchs/`, mirroring current layout: `benchs/r_code/`, `benchs/ttsl/`). Update script and doc paths; keep existing test modules and parametrization **unchanged in behavior** (moves and import path fixes only).
+
+- **Bash-only entry points** — Delete `scripts/bench_material.ps1`. Document running benchmarks via `bash scripts/...` from the repository root (Windows: Git Bash / WSL per `AGENTS.md` platform notes). **No new `.ps1` bench scripts.**
+
+- **Few consolidated scripts** — Replace ad-hoc per-module pytest invocations with a **small canonical set** (target **three** suite scripts plus one optional aggregator):
+
+  | Script | Covers (existing modules only) |
+  |--------|--------------------------------|
+  | `scripts/bench_material.sh` | Material apply (`test_bench_r_pix_shader.py`) |
+  | `scripts/bench_r_code.sh` | Triangle raster + Textual export (`test_bench_triangle_raster.py`, `test_bench_to_textual.py`) |
+  | `scripts/bench_ttsl.sh` | TTSL VM (`test_bench_ttsl.py`) |
+  | `scripts/bench_all.sh` *(optional)* | Runs the three scripts sequentially; timestamped JSON under `benchmarks/` |
+
+  Retire `scripts/bench_to_textual.sh` as a separate public entry point once its suite is covered by `bench_r_code.sh` (or keep as thin alias that calls the consolidated script—implementation choice; **one** documented path per suite in docs).
+
+- **Human-readable output for every suite** — Each `bench_*.sh` must: run `pytest` with `--benchmark-only` and `--benchmark-json=…`, then invoke a **report step** that prints Rich tables (~100-column friendly), matching material’s UX. Refactor `dev_material_bench_report.py` into shared helpers + suite-specific or parameterized reporters; **no suite should end on JSON-only** unless JSON is explicitly secondary (printed path + table above).
+
+- **Contributor docs** — Add a **Benchmarks** subsection to `AGENTS.md` (commands, output location, when to run before perf PRs). Update **`README.md`** to remove `.ps1` references and point to the consolidated bash scripts and `benchs/` layout.
+
+- **CI unchanged in intent** — `fast-checks.yml` continues `uv run pytest` with **no** benchmark collection after relocation. No wall-time gates on runners.
 
 ## Non-goals
 
-- **Hard SLA gates** on wall time in default CI (flaky across runners).
-- **Replacing** Rust-native microbenches for pure-Rust helpers where Criterion is already the right tool.
-- **Distributed** or cloud perf lab; **profiling-as-a-service** is out of scope (local + optional CI artifact is enough).
-- **Rewriting** all demos as benchmarks—prefer **minimal synthetic buffers** like existing bench tests.
+- **Adding new benchmark scenarios** — No new parametrizations, sizes, shaders, or hotspot coverage beyond what exists today.
+- **Deep changes to bench inner loops** — Do not change `FRAME_LOOPS`, `ROUND_LOOPS`, `SIZES`, triangle counts, `PASS_CONFIG`, or the functions under measurement except as required by file moves/import paths.
+- **PowerShell bench scripts** — Remove existing `.ps1`; do not replace them.
+- **`slow_benchmark` pytest marker** — Superseded by relocation; not part of this evolution.
+- **Hard SLA / perf gates in CI** — No timing assertions on shared runners.
+- **New Rust Criterion benches** or **pyinstrument** guide — Optional follow-up only.
+- **Sphinx `source/` pages** — Unless a single cross-link is trivial; primary docs are `AGENTS.md` + `README.md`.
+- **Rewriting demos** as benchmarks.
 
 ## User-visible functionality
 
-- **Maintainers and contributors** — One command per benchmark family with **human-readable tables** (and optional JSON for spreadsheets or historical tracking).
-- **Library consumers** — **No public API change** required for the benchmarking slice; any new **optional** env vars or markers are contributor-facing only unless the team later exposes a documented `python -m tt3de.bench` entry (defer unless needed).
-- **CI** — Default pipeline remains **green without** long benchmark phases; documented command to run the full perf suite before releases or when touching hot paths.
+- **Maintainers** — Run `bash scripts/bench_material.sh`, `bash scripts/bench_r_code.sh`, or `bash scripts/bench_ttsl.sh` from the repo root; see Rich summary in the terminal; optional JSON under `benchmarks/` for history.
+- **Library consumers** — No public API changes.
+- **CI** — Faster, clearer separation: pytest = tests; `scripts/bench_*.sh` = performance.
 
 ## Technical approach
 
@@ -64,75 +79,122 @@ Grow a **small, repeatable set of performance benchmarks** for tt3de’s CPU ras
 
 | Piece | Role today |
 |-------|------------|
-| `pytest-benchmark` | Drives timed loops; dev dep in `pyproject.toml`. |
-| `tests/benchs/r_code/conftest.py` | Tightens default benchmark columns (`min`, `max`, `mean`, `median`, `ops`) and sort for that subtree. |
-| `scripts/bench_material.sh` | End-to-end material bench + JSON + Rich. |
-| `scripts/dev_material_bench_report.py` | Parses pytest-benchmark JSON, prints Rich tables/panels. |
-| CI | `uv run pytest` in `fast-checks.yml` with no benchmark exclusion. |
+| `tests/benchs/**` | `pytest-benchmark` modules; collected by default CI pytest |
+| `tests/benchs/r_code/conftest.py` | Compact benchmark columns when r_code benches collected |
+| `scripts/bench_material.sh` | Material bench + JSON + Rich via `dev_material_bench_report.py` |
+| `scripts/bench_material.ps1` | Windows duplicate of material script (**to remove**) |
+| `scripts/bench_to_textual.sh` | Textual bench + JSON + `enrich_benchmark_json.py` (**no Rich table**) |
+| `benches/*.rs` | Criterion microbenches (unchanged) |
+| CI | `uv run pytest` collects `tests/benchs/` |
 
 ### Proposed change
 
-1. **Inventory** — List each existing `tests/benchs/**` node and classify: *quick smoke* vs *heavy* (large `parametrize` grids, big buffers). Align naming: `@pytest.mark.benchmark` groups already exist (`material_shading`, `triangle_raster`, `ttsl_run`, etc.).
-2. **CI split** — Register **`slow_benchmark`** in pytest config; apply `@pytest.mark.slow_benchmark` to heavy bench tests after inventory. Update **`fast-checks.yml`** to `uv run pytest -m "not slow_benchmark"`. Bench shell scripts continue to target specific nodes with `--benchmark-only` (unaffected by the CI filter). Optionally add one **unmarked** cheap smoke under `tests/benchs/` if the team wants a minimal perf path exercised on every PR.
-3. **Scripts + reports** — For 2–4 additional hotspots, add shell entry points and either extend the Rich reporter with **pluggable group filters** or duplicate the minimal JSON parsing with shared helpers in `scripts/` (avoid copy-paste drift if the JSON schema is shared).
-4. **Optional full-suite runner** — Single `scripts/bench_all.sh` that invokes the per-suite scripts sequentially and writes timestamped JSON files (optional zip of `benchmarks/` for upload in manual CI).
+**Phase 1 — Relocate**
 
-### Future / optional phases
+1. Move `tests/benchs/` → `benchs/` (preserve `r_code/`, `ttsl/`, `conftest.py` structure).
+2. Add `benchs/conftest.py` if needed for shared pytest-benchmark column defaults (lift from `tests/benchs/r_code/conftest.py` or keep under `benchs/r_code/` only).
+3. Ensure scripts set `PYTHONPATH` to include `python/` (and repo root if tests imported from `tests.*` today—adjust to minimal imports: `tt3de` only).
+4. Delete empty `tests/benchs/` after move; grep repo for `tests/benchs` (README, skills, evolution links, CHANGELOG) and update.
 
-- **Criterion / `cargo bench`** cross-links in the same doc table where a hotspot is Rust-dominated with little Python.
-- **`pyinstrument`** (already a dev dependency)—optional one-pager on how to attach to a bench script for **flame-oriented** investigation after a regression is spotted.
-- **Historical tracking** — pytest-benchmark `--benchmark-autosave` / compare mode; document but do not mandate storage.
+**Phase 2 — Scripts and reporting**
+
+1. Delete `scripts/bench_material.ps1`.
+2. Implement `scripts/bench_r_code.sh` and `scripts/bench_ttsl.sh`; update `bench_material.sh` paths to `benchs/…`.
+3. Extract shared JSON → Rich utilities (e.g. `scripts/bench_report_lib.py` or refactor `dev_material_bench_report.py`); add reporters for raster and Textual suites (group by existing `benchmark` group / params: `size`, `pattern`, `mode`, etc.).
+4. Merge or alias `bench_to_textual.sh` into `bench_r_code.sh`; document one path.
+5. Optional `scripts/bench_all.sh` calling the three suite scripts.
+
+**Phase 3 — Documentation**
+
+1. **`AGENTS.md`** — New bullets under Testing (or dedicated Benchmarks): prerequisite `uv run maturin develop`; table of scripts → what they measure → units (per batch vs per invocation); `benchmarks/` output; note that CI pytest excludes `benchs/`; relative comparisons for PRs, not absolute ms SLAs.
+2. **`README.md`** — Replace material-only + `.ps1` section with the three bash commands and pointer to `AGENTS.md` for detail.
+
+### Target layout (after implementation)
+
+```text
+benchs/
+  r_code/
+    conftest.py
+    test_bench_r_pix_shader.py
+    test_bench_triangle_raster.py
+    test_bench_to_textual.py
+  ttsl/
+    test_bench_ttsl.py
+benchmarks/          # JSON artifacts (gitignored or committed per existing policy)
+scripts/
+  bench_material.sh
+  bench_r_code.sh
+  bench_ttsl.sh
+  bench_all.sh       # optional
+  dev_material_bench_report.py  # thin CLI or merged into shared report module
+```
 
 ### Alternatives considered
 
-- **Dedicated Rust harness only** — Rejected as primary: misses PyO3 and Textual integration costs.
-- **Always-on CI benchmarks** — Rejected: noisy and slow on shared runners.
-- **`--ignore=tests/benchs/` on CI** — Rejected: drops the whole subtree and blocks a future **cheap smoke** test in that folder. **Chosen:** `slow_benchmark` marker + `pytest -m "not slow_benchmark"` on the fast job.
-- **Moving benches outside `tests/`** — Possible, but breaks discoverability; not needed with markers.
+| Alternative | Decision |
+|-------------|----------|
+| `slow_benchmark` marker + `pytest -m "not slow_benchmark"` | **Rejected** — relocation avoids marker drift on every new bench file. |
+| `--ignore=tests/benchs` in CI | **Rejected** — benches should not live under `tests/` at all. |
+| Keep benchmarks in `tests/` + ignore | **Rejected** — same as above; wrong directory semantics. |
+| PowerShell `.ps1` wrappers | **Rejected** — bash-only; Git Bash on Windows. |
+| JSON-only output for some suites | **Rejected** — all suite scripts print Rich summary. |
+| `python -m tt3de.bench` CLI | **Deferred** — scripts sufficient. |
 
 ### Affected subsystems
 
-Python tests, `scripts/`, CI YAML, contributor docs (`AGENTS.md`). Rust code only if new `#[bench]` or exposed C API helpers are added (not required for phase 1).
+`benchs/` (new location), `scripts/`, `AGENTS.md`, `README.md`, grep cleanup in `.cursor/skills/` and `.opencode/skills/` if they reference `tests/benchs/` or `.ps1`. **No Rust hot-path changes** unless import paths in bench files require it. CI YAML unchanged except benefiting from faster pytest. `pyproject.toml` unchanged unless a `[tool.pytest.ini_options] testpaths` tweak is needed (default discovery should not include `benchs/`).
 
 ## Usability and documentation
 
-- **`AGENTS.md` Testing section** — Bullet: “Performance: run `scripts/bench_*.sh` locally; CI runs `pytest -m \"not slow_benchmark\"`.”
-- **`source/`** — Short cross-link from developer or testing narrative if one exists; otherwise keep scope in `AGENTS.md` to avoid duplicating Sphinx without need.
-- **README** — Optional single line pointing to `bench_material.sh` siblings once they exist.
+- **`AGENTS.md`** — Canonical benchmark commands; maturin develop prerequisite; explain `benchmarks/*.json` + terminal report; Windows: `bash scripts/bench_material.sh`.
+- **`README.md`** — Short “Performance benchmarks” subsection listing the three scripts (no `.ps1`).
+- **PR workflow** — When claiming perf changes: run relevant `bench_*.sh`, paste Rich output or attach JSON; compare **relative** speedups on the same machine.
 
 ## Testability
 
-- Bench tests remain **non-asserting on absolute time**; they assert **correctness fixtures** where applicable (existing pattern: build buffers, run function under `benchmark`).
-- **Optional cheap smoke** — A single fast test under `tests/benchs/` **without** `slow_benchmark` can stay in default CI (correctness or one timing sample); all heavy parametrized grids get the marker.
-- **Regression workflow**: contributor runs full suite locally, attaches JSON or screenshot of Rich output to PR when claiming perf wins.
+- Bench modules keep **no absolute timing assertions**; behavior under measurement unchanged.
+- **Regression**: after relocation, each `bench_*.sh` exits 0 and prints expected groups; `uv run pytest` does not list `benchs/` nodes (`pytest --collect-only` sanity).
+- **Optional**: a one-line CI check that `pytest --collect-only 2>&1 | grep -q benchs` fails (no accidental reintroduction under `tests/`).
 
 ## Complexity and scope
 
-- **Size: M** — Touches CI, multiple scripts, and possibly refactors report code.
-- **Risk hotspots** — Accidentally tagging non-bench tests with `slow_benchmark`, or forgetting the marker on new heavy benches; **verify collection** with `pytest --collect-only -m "not slow_benchmark"` in CI or a dedicated check step.
-- **Incremental ship** — (1) CI exclusion + docs, (2) one new bench script + report generalization, (3) remaining suites.
+- **Size: M** — File moves, script consolidation, report refactor, doc updates; low risk to engine correctness.
+- **Risk hotspots** — Stale `tests/benchs` paths in docs/skills; forgotten `.ps1` references; `bench_r_code.sh` grouping wrong pytest nodeids after move.
+- **Incremental ship** — (1) relocate + fix material script, (2) r_code + ttsl scripts + Rich for all suites, (3) docs + delete `.ps1` + optional `bench_all.sh`.
 
 ## A priori performance analysis
 
-- **Hot paths** — Per-pixel material (`apply_material_*`), raster passes (`raster_all_py`), TTSL bytecode execution (`ttsl_run`), buffer clears/resizes, Textual render hooks.
-- **Expectations** — Parallel material paths depend on core count; document **machine metadata** line (already in Rich report pattern) and prefer **relative** comparisons (serial vs parallel, before vs after patch) over absolute ms claims.
-- **Validation** — After changes: run the same script twice, compare JSON or Rich side-by-side; use smaller `SIZES` grids for quick iteration.
+- **Hot paths** (unchanged) — `apply_material_*`, `raster_all_py`, `ttsl_run`, `DrawingBufferPy.to_textual_2`.
+- **Expectations** — Numbers should match pre-move runs within noise; document machine line in Rich output for cross-machine humility.
+- **Validation** — Run `bench_material.sh` before and after Phase 1; compare JSON means for one `n` and serial mode.
 
 ## Risks and open questions
 
-- **CI collection drift** — If new heavy bench tests land without `slow_benchmark`, they run on every PR and **slow CI**; code review checklist: “heavy benchmarks marked `slow_benchmark`?”
-- **Windows parity** — Bash scripts are fine if documented with `bash scripts/...` on Windows; add `.ps1` wrappers only if the team wants first-class PowerShell without Git Bash.
-- **Open question (minor)** — Whether to add one **unmarked** cheap smoke under `tests/benchs/` for CI; default is **no** until a concrete test is identified.
+- **Skill/doc drift** — `tt3de-low` and `ttsl-implementation` skills mention `tests/benchs/`; update in the same PR series as the move.
+- **`opcode_speedtest.py`** under `tests/benchs/ttsl/` — Confirm whether it is a bench or dev script; move with `benchs/ttsl/` or leave/delete if dead (inventory during Phase 1).
+- **Open (minor)** — Whether `bench_all.sh` is worth shipping in v1 or documented as `for s in scripts/bench_*.sh; do bash "$s"; done`.
 
 ## Decision record
 
-- **CI exclusion (2026-05-16)** — Use pytest marker **`slow_benchmark`** on heavy benchmark tests; **fast CI** runs `pytest -m "not slow_benchmark"`. Reject `--ignore=tests/benchs/` so the folder can host an optional cheap smoke later.
-- **Still open when closing** — Whether the Rich reporter was generalized or forked, and which `scripts/bench_*.sh` entry points are canonical beyond material.
+- **2026-05-19 — Scope refinement (authoritative)**  
+  - **In:** bash-only; consolidate to few `scripts/bench_*.sh`; move benches out of `tests/`; human-readable Rich output for every suite; update `AGENTS.md` + `README.md`.  
+  - **Out:** new benchmark scenarios; deep inner-loop changes; `.ps1` scripts; `slow_benchmark` marker approach.
+
+- **2026-05-19 — Relocation over markers**  
+  Store benchmarks under top-level `benchs/` so default `pytest` excludes them. Reject `slow_benchmark` + `pytest -m "not slow_benchmark"` from the 2026-05-16 draft.
+
+- **2026-05-19 — Script consolidation**  
+  Target three suite scripts (`bench_material.sh`, `bench_r_code.sh`, `bench_ttsl.sh`) plus optional `bench_all.sh`. Remove `bench_material.ps1` and standalone `bench_to_textual.sh` as the primary documented path.
+
+- **2026-05-19 — Reporting**  
+  Every suite script ends with Rich terminal output; generalize helpers from `dev_material_bench_report.py` rather than leaving JSON-only workflows.
+
+- **Superseded (2026-05-16 draft)** — `slow_benchmark` CI exclusion; adding new `bench_*.sh` for *new* hotspots; PowerShell parity; optional `workflow_dispatch` perf job (remain optional follow-up, not in scope).
 
 ## References
 
-- `scripts/bench_material.sh`, `scripts/dev_material_bench_report.py`
-- `tests/benchs/` tree and `tests/benchs/r_code/conftest.py`
+- `scripts/bench_material.sh`, `scripts/bench_to_textual.sh`, `scripts/dev_material_bench_report.py`
+- `tests/benchs/` (to become `benchs/`)
+- `benches/` (Criterion)
 - `.github/workflows/fast-checks.yml`
-- `source/index.rst` (engine scope)
-- [`AGENTS.md`](../../AGENTS.md) (build/test commands)
+- [`AGENTS.md`](../../AGENTS.md), [`README.md`](../../README.md)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Updates `.evolution/draft/evol-engine-profiling-benchmarks.md` to reflect the agreed implementation scope.

## Scope (in)

- **Bash only** — remove `bench_material.ps1`; no new PowerShell bench wrappers
- **Consolidate** long-running benches behind a small set of `scripts/bench_*.sh` entry points (`bench_material.sh`, `bench_r_code.sh`, `bench_ttsl.sh`, optional `bench_all.sh`)
- **Relocate** benchmarks from `tests/benchs/` to top-level `benchs/` so default `uv run pytest` / CI no longer collects them
- **Human-readable output** for every suite (Rich tables, shared helpers from the material report path)
- **Document** benchmark workflow in `AGENTS.md` and `README.md`

## Out of scope

- New benchmark scenarios or parametrizations
- Deep changes to inner timing loops (`FRAME_LOOPS`, grids, etc.)
- `slow_benchmark` pytest marker approach (superseded by relocation)

Implementation will follow in a separate PR on a feature branch.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e74411ae-6b8f-4e9f-8c7f-8d74a72c50a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e74411ae-6b8f-4e9f-8c7f-8d74a72c50a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

