### PR TITLE
chore: align TTSL skill for shader authoring

### DIFF
--- a/.cursor/rules/demos-standards.mdc
+++ b/.cursor/rules/demos-standards.mdc
@@ -6,7 +6,7 @@ alwaysApply: false
 
 # Demos standards
 
-Applies to scripts under `demos/`. General Python rules: [.cursor/rules/python-standards.mdc](python-standards.mdc). TTSL semantics and compiler depth: [.cursor/skills/ttsl-implementation/SKILL.md](../skills/ttsl-implementation/SKILL.md), `source/ttsl.md`, `source/ttsl_compiler.md`.
+Applies to scripts under `demos/`. General Python rules: [.cursor/rules/python-standards.mdc](python-standards.mdc). **`SHADER_SRC` bodies** are authored by [.cursor/skills/ttsl-implementation/SKILL.md](../skills/ttsl-implementation/SKILL.md); [.cursor/skills/tt3de-demomaker/SKILL.md](../skills/tt3de-demomaker/SKILL.md) wires demos and delegates TTSL. Reference `source/ttsl.md`, `source/ttsl_compiler.md` for semantics when integrating.
 
 ## Layout and naming
 

--- a/.cursor/skills/tt3de-demomaker/SKILL.md
+++ b/.cursor/skills/tt3de-demomaker/SKILL.md
@@ -1,11 +1,12 @@
 ---
 name: tt3de-demomaker
 description: >-
-  Adds or edits runnable tt3de demos under demos/ using Textual and TT3DViewStandAlone,
-  including TTSL ShaderPy materials, 2D/3D scene graphs, textures, and camera setup.
-  Runs a short discovery pass first (what to showcase, 2d vs 3d, TTSL vs geometry, etc.) with
-  suggested answers the user can accept via shorthand. Use when the user asks for a demo,
-  example app, standalone viewer, or demos/2d or demos/3d scripts.
+  Adds or edits runnable tt3de demos under demos/ using Textual and TT3DViewStandAlone:
+  app skeleton, scene graph, ShaderPy wiring, textures, and camera setup. Does not
+  author TTSL shader source—delegates SHADER_SRC to ttsl-implementation. Runs a short
+  discovery pass first with suggested answers the user can accept via shorthand. Use
+  when the user asks for a demo, example app, standalone viewer, or demos/2d or demos/3d
+  scripts.
 disable-model-invocation: true
 ---
 
@@ -13,17 +14,43 @@ disable-model-invocation: true
 
 ## Scope
 
-Orchestrate **new or edited demos** in `demos/`: run discovery, then implement following repo rules.
+Orchestrate **new or edited demos** in `demos/`: run discovery, then implement **Python demo plumbing** following repo rules.
 
-**Technical** (layout, ShaderPy, scene graph, textures, docstrings, comments, checklist): `.cursor/rules/demos-standards.mdc` (globs `demos/**/*.py`). **General Python**: `.cursor/rules/python-standards.mdc`.
+You **own:** Textual app shell, `TT3DViewStandAlone` lifecycle, scene graph, camera, texture registration, material slot 0 sentinel, `all_passes_compilation` / `ShaderPy` / `set_shader_time` **wiring**, module docstrings, and demo checklists.
 
-**TTSL** (language, compiler, opcodes, ABI): `.cursor/skills/ttsl-implementation/SKILL.md`, plus `source/ttsl.md` and `source/ttsl_compiler.md`.
+You **do not own:** contents of `SHADER_SRC` (the TTSL function bodies), TTSL language fixes, compiler opcodes, or `source/ttsl.md` semantics. For any of that, **delegate** to [ttsl-implementation](../ttsl-implementation/SKILL.md) (invoke that skill or ask the user to run it)—do not draft or “quick fix” TTSL yourself.
 
-**Textual-heavy demos** (especially `demos/ttsl.py`): `.cursor/rules/textual-ui-helper.mdc`.
+**Technical** (layout, ShaderPy integration patterns, checklist): [.cursor/rules/demos-standards.mdc](../../rules/demos-standards.mdc) (globs `demos/**/*.py`). **General Python**: [.cursor/rules/python-standards.mdc](../../rules/python-standards.mdc).
+
+**Textual-heavy demos** (especially `demos/ttsl.py`): [.cursor/rules/textual-ui-helper.mdc](../../rules/textual-ui-helper.mdc).
+
+Read `source/ttsl.md` / `source/ttsl_compiler.md` only when wiring uniforms or choosing static vs shader materials—not to invent shader algorithms.
+
+## TTSL delegation (required)
+
+| You may | You must not |
+|---------|----------------|
+| Decide *whether* the demo uses `ShaderPy` vs static materials | Write or rewrite `SHADER_SRC` lines (entry function, builtins, math, transparency) |
+| Pass `SHADER_SRC` into `all_passes_compilation` after the TTSL skill supplies it | Patch compile errors by editing TTSL “just enough to compile” |
+| Wire `globals_dict`, `register_seed`, `time_f32_reg`, `set_shader_time` | Add opcodes, edit `compiler.py`, or change `low_level_def.py` |
+| Copy an **existing** demo’s `SHADER_SRC` unchanged when mirroring that demo | Invent new TTSL beyond what **ttsl-implementation** produced |
+
+**Workflow when the demo needs custom shading:**
+
+1. Finish discovery (include a short **shader intent** brief: inputs, effect, animated or not).
+2. **Stop** before filling `SHADER_SRC`, or leave a clearly marked placeholder.
+3. **Delegate:** invoke [ttsl-implementation](../ttsl-implementation/SKILL.md) with the intent, entry function name, and required `globals_dict` keys; integrate the returned source.
+4. If compilation fails or behavior is wrong in the shader, **do not edit TTSL**—tell the user to run **ttsl-implementation** again (or switch to that skill) with the error / desired fix.
+
+**User-facing message template** (adapt, do not parrot):
+
+> This demo needs TTSL shader source. Use the **ttsl-implementation** skill (or @-mention it) to write/fix `SHADER_SRC` for `<entry_fn>` with `<brief intent>`. I can wire `ShaderPy`, scene graph, and textures once the shader compiles.
 
 ## Discovery before implementation
 
-**Do not write or edit demo code until discovery is settled.** First surface what the demo should **showcase** (one primary teaching goal) and any **implementation specifics** (dimensionality, animation, TTSL vs static materials, textures, camera, interaction, filename/location).
+**Do not write or edit demo code until discovery is settled.** First surface what the demo should **showcase** (one primary teaching goal) and any **implementation specifics** (dimensionality, animation, shader vs static materials, textures, camera, interaction, filename/location).
+
+When shading is TTSL-based, capture **shader intent** in discovery (uniforms, varyings, effect)—that brief goes to **ttsl-implementation**, not into improvised `SHADER_SRC` in this skill.
 
 ### How to ask
 
@@ -40,11 +67,21 @@ If the user already stated goals unambiguously in their latest message, **still 
 
 ### Typical question themes (examples only)
 
-Use a subset that fits the request: primary showcase, 2D vs 3D, static vs animated, TTSL entry vs no shader, textures/assets, camera framing, demo path (`demos/2d` vs `demos/3d`), and whether to mirror an existing demo.
+Use a subset that fits the request: primary showcase, 2D vs 3D, static vs animated, **shader intent** (for ttsl-implementation) vs no shader, textures/assets, camera framing, demo path (`demos/2d` vs `demos/3d`), and whether to mirror an existing demo (reuse its `SHADER_SRC` verbatim only when mirroring).
 
 ## After discovery
 
-Implement against `.cursor/rules/demos-standards.mdc` and `.cursor/rules/python-standards.mdc`. Use the **Checklist** at the bottom of `demos-standards.mdc`, and confirm discovery is settled (or explicitly waived with `1:y`-style confirmation to proceed).
+Implement against [.cursor/rules/demos-standards.mdc](../../rules/demos-standards.mdc) and [.cursor/rules/python-standards.mdc](../../rules/python-standards.mdc). Use the **Checklist** at the bottom of `demos-standards.mdc`, and confirm discovery is settled (or explicitly waived with `1:y`-style confirmation to proceed).
+
+If `SHADER_SRC` is still missing, complete all non-TTSL wiring and block on **ttsl-implementation** rather than writing placeholder shader logic beyond `pass`-level stubs.
 
 Do not attempt to run the demo; since it's a TUI application, you are going to have problems running it.
 If you need validation, ask the user to run the demo and report results.
+
+## Verification checklist (demomaker)
+
+- [ ] Discovery settled; shader intent documented if using `ShaderPy`
+- [ ] `SHADER_SRC` authored by **ttsl-implementation** (or copied unchanged from an existing demo being mirrored)
+- [ ] No TTSL edits made in this skill for compile fixes or effect tweaks
+- [ ] Slot-0 static material, `ShaderPy`, `globals_dict` / `set_shader_time` wired per demos-standards
+- [ ] Module docstring with **Run:** line; user asked to run TUI if validation needed

--- a/.cursor/skills/ttsl-implementation/SKILL.md
+++ b/.cursor/skills/ttsl-implementation/SKILL.md
@@ -1,121 +1,186 @@
 ---
 name: ttsl-implementation
-description: Implements or changes Tiny Tiny Shader Language (TTSL) shaders, compiler, VM opcodes, or TTSL-related docs in tt3de. Use when writing TTSL source, editing python/tt3de/ttsl/, Rust TTSL VM/material paths,   or when the user mentions TTSL, shader materials, bytecode, builtins (tt_FragCoord, tt_Time), all_passes_compilation, ttsl_run, ShaderPy, gen-opcodes, low_level_def, or opcode definitions.
+description: >-
+  Writes and edits Tiny Tiny Shader Language (TTSL) shader source, and implements
+  compiler / VM / opcode changes when needed. Use for TTSL materials, shading logic,
+  all_passes_compilation, ttsl_run, ShaderPy, globals_dict, tt_* builtins,
+  tt_texture, or extending python/tt3de/ttsl/, low_level_def, gen-opcodes.
 disable-model-invocation: true
 ---
 
-# TTSL implementation
+# TTSL coder
 
-## Documentation map
+You are the **TTSL language specialist** in tt3de. Default to **authoring correct shader source** that compiles and matches engine semantics. Touch the compiler, ISA, or Rust VM only when the task is explicitly to add or change language / opcode behavior.
 
-Read these before changing behavior; they are the contract:
+## Documentation map (read first)
+
+These files are the contract; prefer them over memory or GLSL habits:
 
 | Topic | File |
 |-------|------|
-| Builtins, uniforms, texture ABI, material bridge | [source/ttsl.md](../../../source/ttsl.md) |
-| Compiler API, `globals_dict`, supported syntax | [source/ttsl_compiler.md](../../../source/ttsl_compiler.md) |
+| Builtins, uniforms, textures, transparency, material bridge | [source/ttsl.md](../../../source/ttsl.md) |
+| `globals_dict`, compile API, pipeline overview | [source/ttsl_compiler.md](../../../source/ttsl_compiler.md) |
 | Opcode numbers and operand types (generated) | [source/opcode_reference.md](../../../source/opcode_reference.md) |
 
-## Authoring shader source
+**Shipped vs Planned:** the primitives table in `source/ttsl.md` lists intent. Before using a function name, confirm it compiles (grep `tests/tt3de/ttsl/` or run `all_passes_compilation` on a minimal snippet). **Planned** or **Missing** rows are not safe to use in production shaders unless you are implementing them in the same change.
 
-- **Return type**: `(front, back, glyph)` as `(vec4, vec4, int)`, matching VM `OP_RET`. Annotate `tuple[vec4, vec4, int]` (or `typing.Tuple[...]`) when typing the entry function.
-- **Per-cell builtins** (`tt_FragCoord`, `tt_FragPos`, `tt_Normal`, `tt_ViewPos`, `tt_TexCoord0`, `tt_TexCoord1`, `tt_FrontFacing`, `tt_FragDepth`, `tt_LineCoord`, `tt_PointCoord`, `tt_PrimitiveID`): known to the compiler; see `ttsl_compiler.md` for parameter declarations vs implicit slots.
-- **Engine uniforms** (`tt_Time`, `tt_DeltaTime`, `tt_Frame`, `tt_Resolution`, `tt_Near`, `tt_Far`): include in `globals_dict` with the types documented in `ttsl.md` / `ttsl_compiler.md`; wire runtime setters and `ShaderPy.*_reg` to match `RegisterSettings` after `all_passes_compilation`.
-- **Naming**: `tt_` + CamelCase, analogous to GLSL `gl_`.
-- **Sampling**: only `tt_texture(index: int, coord: vec2) -> vec4` (and `tt_texelFetch` when implemented end-to-end—confirm opcode + compiler + tests). Use `tt_TexCoord*` for interpolated coords. Standalone Python `ttsl_run` does not bind textures; expect black or engine-defined fallback unless exercising through `Shader` + `TextureBuffer`.
-- **Python next to shaders**: `from pyglm import glm` (same prelude convention as AGENTS.md).
+## Scope and boundaries
 
-## Compiler and bytecode
+| Task | This skill | Hand off |
+|------|------------|----------|
+| Write / fix shader `SHADER_SRC`, uniforms, sampling, fog, transparency | **Yes** | — |
+| Compile, seed registers, `ttsl_run` smoke tests | **Yes** | — |
+| Textual demos using `ShaderPy` | **Yes** (shader body); wiring checklist in [demos-standards](../../../.cursor/rules/demos-standards.mdc) | [tt3de-demomaker](../tt3de-demomaker/SKILL.md) for discovery |
+| New TTSL builtin needing texture buffer / raster / material bridge in Rust | Opcode + compiler here | [tt3de-low](../tt3de-low/SKILL.md) for engine hook |
+| Scene graph, prefabs, loaders (no TTSL) | — | [tt3de-high](../tt3de-high/SKILL.md) |
 
-- **Pipeline entry**: `all_passes_compilation(src, func_name, globals_dict)` in `python/tt3de/ttsl/compiler.py`.
-- **ISA / opcode definition changes**: edit `python/tt3de/ttsl/ttisa/low_level_def.py`, then run `make gen-opcodes` or `bash scripts/gen_opcodes.sh` (PowerShell script on Windows). That refreshes Rust opcodes, Python opcode tables, and `source/opcode_reference.md`.
-- **Lowering gaps**: consult `source/ttsl_compiler.md` (supported features, typability in `type_of`, notes like partially wired helpers). Do not assume a name in `ttsl.md` primitives table compiles until verified in the compiler and tests.
+## What TTSL is
 
-## Key architecture: what is generated vs manual
+TTSL is a **typed, Python-syntax shader subset** compiled to tt3de VM bytecode. It is **not** full Python: no imports inside shader source, no `for` loops, no classes, no lambdas, no list/dict literals as language features. The compiler strips bare `print` and import statements from the parsed function body.
 
-**`src/ttsl/opcodes.rs` is fully auto-generated** by `low_level_def.py` via `gen-opcodes`. Never hand-edit it. The generator builds the entire Rust `exec_opcode` match block from Python `Form` definitions, including `unsafe` register access. For standard math operations the Rust VM implementation requires zero manual Rust coding.
+- **Types:** `float`, `int`, `bool`, `vec2`, `vec3`, `vec4` (construct with `vec2(...)` / `glm.vec2(...)`).
+- **GLM:** host Python uses `from pyglm import glm`; in shaders prefer **`glm.sin`**, **`glm.vec4`**, etc. when that matches existing demos—many bare names (`sin`, `clamp`, `mod`) also work when listed below.
+- **Naming:** engine builtins use `tt_` + CamelCase (GLSL `gl_` analogue), e.g. `tt_FragCoord`, `tt_Time`.
 
-**`PassToByteCode.find_form` is generic.** It matches IR instructions to bytecode forms by checking `instr.op.name in form["name"]` (substring) and comparing type tuples. New opcodes that follow existing patterns (unary same-type, binary same-type) need **no back-end changes** — the generic matcher handles them automatically.
+## Shader entry contract
 
-**Opcode index assignment is sequential** across all `CategoryGroup`s in `generate_all_forms()`. Adding forms anywhere shifts downstream indices. Always regenerate after ISA edits; never hand-edit `ttisa_opcodes.py` or `opcodes.rs`.
+Every entry function must **`return (front, back, glyph)`** with types **`(vec4, vec4, int)`** (VM `OP_RET`).
 
-## Adding a new builtin (end-to-end)
+- **`front` / `back`:** RGBA for the terminal cell’s foreground and background halves. Shader materials write these **directly**—there is no post-pass alpha compositing. See **Transparency** below.
+- **`glyph`:** glyph index (`int`); `0` is common when color alone drives the look.
 
-Determine the **shape** of the new builtin first — this determines which pattern to follow:
+Annotate the return type: `-> tuple[vec4, vec4, int]`. List builtins as parameters when you want explicit slots (e.g. `tt_TexCoord0: vec2`); omitting them still works for implicit per-cell inputs.
 
-### Pattern A: Unary math (like `sin`, `abs`, `floor`, `ceil`, `fract`)
+### Builtins and `globals_dict`
 
-Signature: `func(x) -> T` where input and output share the same type (F32, V2, V3, V4).
+| Category | Names | `globals_dict` |
+|----------|-------|----------------|
+| **Per-cell inputs** | `tt_FragCoord`, `tt_FragPos`, `tt_Normal`, `tt_ViewPos`, `tt_TexCoord0`, `tt_TexCoord1`, `tt_FrontFacing`, `tt_FragDepth`, `tt_LineCoord`, `tt_PointCoord`, `tt_PrimitiveID` | **Do not** list—compiler + material bridge fill each pixel |
+| **Engine uniforms** | `tt_Time`, `tt_DeltaTime`, `tt_Frame`, `tt_Resolution`, `tt_Near`, `tt_Far` | **Include** each name the shader reads, mapped to `float`, `int`, or `glm.vec2` **type objects** (not runtime values) |
+| **User uniforms** | e.g. `u_color`, `u_TextureIndex` | Same: name → type; after compile use `RegisterSettings.set_variable` and `register_seed=reg_settings.get_register_list()` on `ShaderPy` |
 
-**Files to edit (in order):**
+`globals_dict` values are **types only**. Runtime values go through `set_variable`, `ShaderPy.*_reg`, and `MaterialBufferPy.set_shader_*` for engine uniforms. Details and examples: `source/ttsl_compiler.md`.
 
-1. **`python/tt3de/ttsl/ttsl_assembly.py`** — Add `MYOP = "myop"` to the `OpCodes` enum.
+Use `GLOBAL_VAR_TT_TIME` from `tt3de.ttsl.compiler` in host Python when wiring `tt_Time` (matches demos).
 
-2. **`python/tt3de/ttsl/ttisa/low_level_def.py`** — Three changes:
-   - Add `OpCodes.MYOP` to both `MATH_FUNCTION_NATIVE_TYPES` (F32 method syntax: `"{a}.myop()"`) and `MATH_FUNCTION_VEC_TYPES` (nalgebra_glm free function: `"myop(&{a})"`).
-   - Add `OpCodes.MYOP` to the unary ops list inside the `"Unary Math"` `CategoryGroup` in `generate_all_forms()`.
-   - Add the nalgebra_glm symbol to the `use nalgebra_glm::{...}` line in `RUST_OPCODE_FILE_PRELUDE` inside `main()`.
+### Textures
 
-3. **`python/tt3de/ttsl/compiler.py`** — Five touch points:
-   - `NATIVE_UNI_OPS_TYPE` dict — add `"myop": (IRType.F32, IRType.V2, IRType.V3, IRType.V4)`.
-   - `compile_expr` bare-call list — add `"myop"` to the `func.id in ("sin", "abs", "cos", "floor", "ceil", "fract", "normalize")` tuple. The `glm.myop(...)` path is handled automatically by the existing `NATIVE_UNI_OPS_TYPE` check.
-   - `type_of` for `ast.Name` — add `"myop"` to the `node.id in ("abs", "sin", "cos", "floor", "ceil", "fract", "normalize")` tuple.
-   - `type_of` for `ast.Attribute` — add `"myop"` to the `node.attr in ("sin", "cos", "floor", "ceil", "fract", "normalize")` tuple.
-   - `opcode_for_uniop` — add `"myop": OpCodes.MYOP` to the `name_to_op` dict (currently maps `sin`, `abs`, `floor`, `ceil`, `fract`, `normalize`).
+- **`tt_texture(texture_index: int, coord: vec2) -> vec4`** — filtered sample; pair with **`tt_TexCoord0`** / **`tt_TexCoord1`** or other `vec2` UVs.
+- Declare texture index in `globals_dict` as `int` (e.g. `"u_TextureIndex": int`) and `set_variable` before `ttsl_run` or engine draw.
+- **`tt_texelFetch`:** specified in `source/ttsl.md` but **not** end-to-end in the compiler yet—do not use until shipped.
+- Standalone **`ttsl_run`** has **no** texture binding (typically black). Full sampling needs **`ShaderPy`** + **`TextureBuffer`** in a demo or test harness.
 
-4. **Regenerate and rebuild** — `bash scripts/gen_opcodes.sh && cargo check --all-targets && uv run maturin develop`.
+### Transparency (critical)
 
-5. **Tests** — Add e2e tests in `tests/tt3de/ttsl/test_e2e.py` using `all_passes_compilation` + `ttsl_run`. Cover: constant input, negative/edge cases, runtime variable input, and `glm.myop(...)` spelling. The `all_passes_compilation` + `ttsl_run` pattern exercises the full pipeline (front end → IR → SSA → bytecode → VM) in one test.
+When texels can be transparent, **mask in the shader**—return black (or your clear color) for both `front` and `back` where alpha is low. For **two UV sets** (`tt_TexCoord0` and `tt_TexCoord1`), mask **each half independently** to avoid key-color fringes. Copy patterns from `source/ttsl.md` (single-path and double-raster examples).
 
-6. **Documentation** — Update the primitives table in `source/ttsl.md`: change row from **Planned** to **Shipped** with notes on supported spellings.
+## Language surface (authoring)
 
-### Pattern B: Binary same-type math (like `mod`)
+Use this when writing shaders today. If something fails with `CompileError` or `NotImplementedError`, check **Pitfalls** before “fixing” the compiler.
 
-Signature: `func(x, y) -> T` where both inputs and output share the same type.
+**Statements:** annotated assignment (`x: float = ...`), plain assignment, `if` / `else`, `while`, `return` (triple only).
 
-If the operation maps to a simple Rust operator (`+`, `-`, `*`, `/`), add it to `generate_binary_unitype_forms`. Otherwise, write a **custom form generator** (see `generate_mod_forms()` for the pattern — it builds `Form` dicts with hand-written `rust_match_code` per type).
+**Operators:** `+ - * /` on scalars and vectors; comparisons `> >= < <=`; boolean `and` / `or` (operands must be `bool`—use comparisons, not `if x:` on floats).
 
-**Files to edit:**
+**Calls — prefer these (bare and/or `glm.*` where noted):**
 
-1. **`python/tt3de/ttsl/ttsl_assembly.py`** — Add `MYOP = "myop"` to `OpCodes`.
+| Category | Names |
+|----------|--------|
+| Unary math | `sin`, `abs`, `floor`, `ceil`, `fract`, `normalize` |
+| Binary / n-ary | `mod`, `dot`, `length`, `max`, `clamp` (3 args) |
+| GLM tools | **`glm.mix(a, b, t)`** — `vec2/3/4` × same × `float` `t`; bare `mix(...)` is **not** wired |
+| Texture | `tt_texture` |
+| Constructors | `vec2`, `vec3`, `vec4`, `glm.vec2`, `glm.vec3`, `glm.vec4` |
+| Swizzles | `.x`, `.y`, `.z`, `.w` on vectors |
 
-2. **`python/tt3de/ttsl/ttisa/low_level_def.py`** — Write a generator function (or extend an existing one) that produces `Form` dicts for each type variant. Add a `CategoryGroup` to `generate_all_forms()`. For vector variants that need component-wise expansion (no nalgebra_glm free function), generate explicit `VecN::new(a.x op b.x, a.y op b.y, ...)` Rust code. Update `RUST_OPCODE_FILE_PRELUDE` imports if needed.
+**Not supported (do not use in shaders):** `for`, `try`, classes, nested `def`, arbitrary Python calls, `min` (not shipped), `sign`, `pow`, `smoothstep`, most of the **Planned** table in `source/ttsl.md`.
 
-3. **`python/tt3de/ttsl/compiler.py`** — Handle both bare `myop(x, y)` and `glm.myop(x, y)`:
-   - `compile_expr` bare call: add an `elif func.id == "myop"` block that validates 2 args, checks same type, compiles both, and calls `self.emit_2(OpCodes.MYOP, ...)`.
-   - `compile_expr` glm attribute: add `elif func_name == "myop"` in the `glm` branch with the same logic.
-   - `type_of` for `ast.Name`: add `elif node.id == "myop"` returning `type_args[0]` after validating 2 same-type args.
-   - `type_of` for `ast.Attribute`: add `elif node.attr == "myop"` with same validation.
+### Pitfalls (common author mistakes)
 
-4. **Regenerate, rebuild, test, document** — same as Pattern A steps 4–6.
+| Looks valid | Actually |
+|-------------|----------|
+| `cos`, `tan` (bare or `glm.cos`) | Often **type-check** but **`opcode_for_uniop` has no `cos`** — use **`sin`** / phase tricks or implement cos in the same change |
+| `min` | **Not shipped** — use `max` on negated values or compare via `if` |
+| `mix(a,b,t)` without `glm.` | **Not wired** — use **`glm.mix`** |
+| `tt_texelFetch` | **Not end-to-end** |
+| Name in `ttsl.md` **Planned** | Verify compile + test before relying on it |
+| `globals_dict` with `tt_FragCoord` | Wrong layer—per-cell builtins are implicit |
+| Expect alpha compositing after return | **Must** zero/mask colors in shader |
+| `ttsl_run` for textured effects | No texture buffer—use engine path or tests that bind textures |
 
-### Pattern C: Special / cross-type operations (like `tt_texture`, `mix`)
+## Workflow: write or change a shader
 
-Operations with mixed input types, engine hooks (texture buffer, etc.), or non-register data need custom handling. See `generate_tt_texture_form()` and `generate_glm_tool_mix_forms()` for examples. **Before coding, confirm with the user** the intended strategy when execution needs data beyond VM registers.
+1. **Read** the relevant sections of `source/ttsl.md` (builtins + primitives + transparency).
+2. **Draft** the entry function: typed locals, explicit `return (front, back, glyph)`.
+3. **Compile** from host Python:
 
-## Rust expression patterns in `low_level_def.py`
+```python
+from pyglm import glm
+from tt3de.ttsl.compiler import GLOBAL_VAR_TT_TIME, all_passes_compilation
 
-| Type | Unary template style | Binary template style |
-|------|---------------------|----------------------|
-| F32 | `"{a}.sin()"` (method on `f32`) | `"{a} + {b}"` (Rust operator) |
-| V2/V3/V4 | `"sin(&{a})"` (nalgebra_glm free fn) | `"{a} + {b}"` (nalgebra operator overload) |
+bytecode, reg_settings = all_passes_compilation(
+    SHADER_SRC,
+    "entry_fn_name",
+    globals_dict={GLOBAL_VAR_TT_TIME: float, "u_MyUniform": glm.vec3},  # only names you read
+)
+```
 
-For operations without a nalgebra_glm free function on vectors, use component-wise expansion: `VecN::new(a_val.x.op(), a_val.y.op(), ...)` — see `_mod_rust_body_vec` for the pattern.
+4. **Smoke-test** when logic is non-trivial:
 
-## Back end: why no changes are usually needed
+```python
+from tt3de.tt3de import ttsl_run
+from tt3de.ttsl.compiler import PIXELVAR_TT_TEXCOORD0
 
-`PassToByteCode.find_form` matches IR instructions to bytecode forms generically:
-- It iterates all forms from `generate_all_forms()`.
-- For non-control-flow ops, it checks `instr.op.name in form["name"]` (e.g. `"FLOOR"` is in `"FLOOR_F32"`).
-- It then compares the full type tuple `(dst_ty, src1_ty, ...)` against `(form output_type, form input_types)`.
-- `transform_instr_to_bytecode` encodes each instruction as `[opcode_index, dst_reg, a_reg, b_reg, c_reg, d_reg]`.
+reg_settings.set_variable(GLOBAL_VAR_TT_TIME, 1.0)
+reg_settings.set_variable(PIXELVAR_TT_TEXCOORD0, glm.vec2(0.5, 0.5))
+front, back, glyph = ttsl_run(*reg_settings.get_register_list(), bytecode)
+```
 
-New opcodes that follow the unary (`emit_1`) or binary (`emit_2`) pattern are matched automatically. You only need to touch `PassToByteCode` for operations with unusual operand layouts (e.g. `TT_TEXTURE` uses `emit(...)` with explicit 4 sources, `MIX` uses 3 sources across different type banks).
+5. **Integrate** into a demo/app: `materials.ShaderPy(..., register_seed=reg_settings.get_register_list())`, material slot 0 static sentinel, `set_shader_time` in `before_render_step`—see [demos-standards](../../../.cursor/rules/demos-standards.mdc) and `demos/2d/ttsl_square.py`.
 
-## Tests and doc updates
+6. **Mirror** non-obvious behavior in `tests/tt3de/ttsl/test_e2e.py` when fixing a regression.
 
-- **E2E tests** in `tests/tt3de/ttsl/test_e2e.py` are the primary validation: compile + `ttsl_run` exercises the entire pipeline. Cover constant inputs, edge cases (negatives, zero), runtime variable inputs, and both bare and `glm.` spellings.
-- **Compiler-only tests** in `tests/tt3de/ttsl/test_compiler.py` for error cases (wrong arg count, type mismatches).
-- Rust-side tests in `src/ttsl/mod.rs` (`#[cfg(test)]`) are only needed for ops that interact with engine surfaces (textures, etc.); pure math ops are fully exercised by the Python e2e path.
-- Run `PYTHONPATH=. uv run pytest tests/tt3de/ -v` to validate (skip `tests/benchs/` which are slow).
-- Update `source/ttsl.md` primitives table in the same change: **Planned** → **Shipped** with notes.
+Do **not** jump to `low_level_def.py` or opcode work when the user only asked for a shader effect solvable with the shipped surface.
+
+## Compiler and bytecode (when extending the language)
+
+**Pipeline entry:** `all_passes_compilation(src, func_name, globals_dict)` in `python/tt3de/ttsl/compiler.py`.
+
+**ISA changes:** edit `python/tt3de/ttsl/ttisa/low_level_def.py`, then `make gen-opcodes` or `bash scripts/gen_opcodes.sh` (PowerShell on Windows). Regenerates Rust opcodes, Python tables, and `source/opcode_reference.md`.
+
+### Generated vs manual
+
+- **`src/ttsl/opcodes.rs` is fully auto-generated** — never hand-edit.
+- **`PassToByteCode.find_form`** matches unary/binary same-type ops generically; unusual layouts (`TT_TEXTURE`, `MIX`, `CLAMP`) need explicit `emit` paths in `compiler.py`.
+- Opcode indices are **sequential** across `generate_all_forms()` — always regenerate after ISA edits; never hand-edit `ttisa_opcodes.py`.
+
+### Adding a new operation (summary)
+
+Pick a pattern by shape; full file-level steps apply when implementing:
+
+| Pattern | Examples | Main touch points |
+|---------|----------|-------------------|
+| **A — Unary same-type** | `sin`, `floor`, `abs` | `ttsl_assembly.py`, `low_level_def.py`, `compiler.py` (`NATIVE_UNI_OPS_TYPE`, bare/`glm` lists, `opcode_for_uniop`), gen-opcodes |
+| **B — Binary same-type** | `mod`, `max` | Same + custom `Form` generator if not a Rust operator |
+| **C — Special** | `tt_texture`, `glm.mix` | Custom `Form` + `compile_expr` / `compile_glm_tool_call`; confirm Rust bridge with user if data leaves VM registers |
+
+After implementation: `bash scripts/gen_opcodes.sh && cargo check --all-targets && uv run maturin develop`, e2e tests in `tests/tt3de/ttsl/test_e2e.py`, compiler errors in `test_compiler.py`, update **`source/ttsl.md`** row **Planned → Shipped**.
+
+**Rust VM tests** (`src/ttsl/mod.rs`) only for engine-coupled ops; pure math is covered by Python e2e.
+
+Run: `PYTHONPATH=. uv run pytest tests/tt3de/ttsl/ -v` (skip `tests/benchs/` unless needed).
+
+## Verification checklist
+
+**Shader-only change**
+
+- [ ] Uses only shipped calls (see **Language surface** / **Pitfalls**)
+- [ ] Correct `globals_dict` (types only; per-cell builtins omitted)
+- [ ] Returns `(vec4, vec4, int)`; transparency handled in-shader if needed
+- [ ] `all_passes_compilation` succeeds; `ttsl_run` or demo path exercised when non-trivial
+
+**Compiler / opcode change**
+
+- [ ] `gen-opcodes` run; no hand-edited `opcodes.rs` / `ttisa_opcodes.py`
+- [ ] `cargo check --all-targets` clean; `uv run pytest tests/tt3de/ttsl/`
+- [ ] `source/ttsl.md` (+ opcode reference via generator) updated

--- a/.cursor/skills/ttsl-implementation/SKILL.md
+++ b/.cursor/skills/ttsl-implementation/SKILL.md
@@ -30,7 +30,7 @@ These files are the contract; prefer them over memory or GLSL habits:
 |------|------------|----------|
 | Write / fix shader `SHADER_SRC`, uniforms, sampling, fog, transparency | **Yes** | — |
 | Compile, seed registers, `ttsl_run` smoke tests | **Yes** | — |
-| Textual demos using `ShaderPy` | **Yes** (shader body); wiring checklist in [demos-standards](../../../.cursor/rules/demos-standards.mdc) | [tt3de-demomaker](../tt3de-demomaker/SKILL.md) for discovery |
+| Textual demos using `ShaderPy` | **Yes** — all `SHADER_SRC` bodies | [tt3de-demomaker](../tt3de-demomaker/SKILL.md) wires the demo only; it **delegates** shader source here |
 | New TTSL builtin needing texture buffer / raster / material bridge in Rust | Opcode + compiler here | [tt3de-low](../tt3de-low/SKILL.md) for engine hook |
 | Scene graph, prefabs, loaders (no TTSL) | — | [tt3de-high](../tt3de-high/SKILL.md) |
 

--- a/.opencode/skills/tt3de-demomaker/SKILL.md
+++ b/.opencode/skills/tt3de-demomaker/SKILL.md
@@ -1,28 +1,56 @@
 ---
 name: tt3de-demomaker
 description: >-
-  Adds or edits runnable tt3de demos under demos/ using Textual and TT3DViewStandAlone,
-  including TTSL ShaderPy materials, 2D/3D scene graphs, textures, and camera setup.
-  Runs a short discovery pass first (what to showcase, 2d vs 3d, TTSL vs geometry, etc.) with
-  suggested answers the user can accept via shorthand. Use when the user asks for a demo,
-  example app, standalone viewer, or demos/2d or demos/3d scripts.
+  Adds or edits runnable tt3de demos under demos/ using Textual and TT3DViewStandAlone:
+  app skeleton, scene graph, ShaderPy wiring, textures, and camera setup. Does not
+  author TTSL shader source—delegates SHADER_SRC to ttsl-implementation. Runs a short
+  discovery pass first with suggested answers the user can accept via shorthand. Use
+  when the user asks for a demo, example app, standalone viewer, or demos/2d or demos/3d
+  scripts.
+disable-model-invocation: true
 ---
 
 # tt3de demomaker
 
 ## Scope
 
-Orchestrate **new or edited demos** in `demos/`: run discovery, then implement following repo rules.
+Orchestrate **new or edited demos** in `demos/`: run discovery, then implement **Python demo plumbing** following repo rules.
 
-**Technical** (layout, ShaderPy, scene graph, textures, docstrings, comments, checklist): `.cursor/rules/demos-standards.mdc` (globs `demos/**/*.py`). **General Python**: `.cursor/rules/python-standards.mdc`.
+You **own:** Textual app shell, `TT3DViewStandAlone` lifecycle, scene graph, camera, texture registration, material slot 0 sentinel, `all_passes_compilation` / `ShaderPy` / `set_shader_time` **wiring**, module docstrings, and demo checklists.
 
-**TTSL** (language, compiler, opcodes, ABI): `.opencode/skills/ttsl-implementation/SKILL.md`, plus `source/ttsl.md` and `source/ttsl_compiler.md`.
+You **do not own:** contents of `SHADER_SRC` (the TTSL function bodies), TTSL language fixes, compiler opcodes, or `source/ttsl.md` semantics. For any of that, **delegate** to [ttsl-implementation](../ttsl-implementation/SKILL.md) (invoke that skill or ask the user to run it)—do not draft or “quick fix” TTSL yourself.
 
-**Textual-heavy demos** (especially `demos/ttsl.py`): `.cursor/rules/textual-ui-helper.mdc`.
+**Technical** (layout, ShaderPy integration patterns, checklist): [.cursor/rules/demos-standards.mdc](../../rules/demos-standards.mdc) (globs `demos/**/*.py`). **General Python**: [.cursor/rules/python-standards.mdc](../../rules/python-standards.mdc).
+
+**Textual-heavy demos** (especially `demos/ttsl.py`): [.cursor/rules/textual-ui-helper.mdc](../../rules/textual-ui-helper.mdc).
+
+Read `source/ttsl.md` / `source/ttsl_compiler.md` only when wiring uniforms or choosing static vs shader materials—not to invent shader algorithms.
+
+## TTSL delegation (required)
+
+| You may | You must not |
+|---------|----------------|
+| Decide *whether* the demo uses `ShaderPy` vs static materials | Write or rewrite `SHADER_SRC` lines (entry function, builtins, math, transparency) |
+| Pass `SHADER_SRC` into `all_passes_compilation` after the TTSL skill supplies it | Patch compile errors by editing TTSL “just enough to compile” |
+| Wire `globals_dict`, `register_seed`, `time_f32_reg`, `set_shader_time` | Add opcodes, edit `compiler.py`, or change `low_level_def.py` |
+| Copy an **existing** demo’s `SHADER_SRC` unchanged when mirroring that demo | Invent new TTSL beyond what **ttsl-implementation** produced |
+
+**Workflow when the demo needs custom shading:**
+
+1. Finish discovery (include a short **shader intent** brief: inputs, effect, animated or not).
+2. **Stop** before filling `SHADER_SRC`, or leave a clearly marked placeholder.
+3. **Delegate:** invoke [ttsl-implementation](../ttsl-implementation/SKILL.md) with the intent, entry function name, and required `globals_dict` keys; integrate the returned source.
+4. If compilation fails or behavior is wrong in the shader, **do not edit TTSL**—tell the user to run **ttsl-implementation** again (or switch to that skill) with the error / desired fix.
+
+**User-facing message template** (adapt, do not parrot):
+
+> This demo needs TTSL shader source. Use the **ttsl-implementation** skill (or @-mention it) to write/fix `SHADER_SRC` for `<entry_fn>` with `<brief intent>`. I can wire `ShaderPy`, scene graph, and textures once the shader compiles.
 
 ## Discovery before implementation
 
-**Do not write or edit demo code until discovery is settled.** First surface what the demo should **showcase** (one primary teaching goal) and any **implementation specifics** (dimensionality, animation, TTSL vs static materials, textures, camera, interaction, filename/location).
+**Do not write or edit demo code until discovery is settled.** First surface what the demo should **showcase** (one primary teaching goal) and any **implementation specifics** (dimensionality, animation, shader vs static materials, textures, camera, interaction, filename/location).
+
+When shading is TTSL-based, capture **shader intent** in discovery (uniforms, varyings, effect)—that brief goes to **ttsl-implementation**, not into improvised `SHADER_SRC` in this skill.
 
 ### How to ask
 
@@ -39,11 +67,21 @@ If the user already stated goals unambiguously in their latest message, **still 
 
 ### Typical question themes (examples only)
 
-Use a subset that fits the request: primary showcase, 2D vs 3D, static vs animated, TTSL entry vs no shader, textures/assets, camera framing, demo path (`demos/2d` vs `demos/3d`), and whether to mirror an existing demo.
+Use a subset that fits the request: primary showcase, 2D vs 3D, static vs animated, **shader intent** (for ttsl-implementation) vs no shader, textures/assets, camera framing, demo path (`demos/2d` vs `demos/3d`), and whether to mirror an existing demo (reuse its `SHADER_SRC` verbatim only when mirroring).
 
 ## After discovery
 
-Implement against `.cursor/rules/demos-standards.mdc` and `.cursor/rules/python-standards.mdc`. Use the **Checklist** at the bottom of `demos-standards.mdc`, and confirm discovery is settled (or explicitly waived with `1:y`-style confirmation to proceed).
+Implement against [.cursor/rules/demos-standards.mdc](../../rules/demos-standards.mdc) and [.cursor/rules/python-standards.mdc](../../rules/python-standards.mdc). Use the **Checklist** at the bottom of `demos-standards.mdc`, and confirm discovery is settled (or explicitly waived with `1:y`-style confirmation to proceed).
+
+If `SHADER_SRC` is still missing, complete all non-TTSL wiring and block on **ttsl-implementation** rather than writing placeholder shader logic beyond `pass`-level stubs.
 
 Do not attempt to run the demo; since it's a TUI application, you are going to have problems running it.
 If you need validation, ask the user to run the demo and report results.
+
+## Verification checklist (demomaker)
+
+- [ ] Discovery settled; shader intent documented if using `ShaderPy`
+- [ ] `SHADER_SRC` authored by **ttsl-implementation** (or copied unchanged from an existing demo being mirrored)
+- [ ] No TTSL edits made in this skill for compile fixes or effect tweaks
+- [ ] Slot-0 static material, `ShaderPy`, `globals_dict` / `set_shader_time` wired per demos-standards
+- [ ] Module docstring with **Run:** line; user asked to run TUI if validation needed

--- a/.opencode/skills/ttsl-implementation/SKILL.md
+++ b/.opencode/skills/ttsl-implementation/SKILL.md
@@ -30,7 +30,7 @@ These files are the contract; prefer them over memory or GLSL habits:
 |------|------------|----------|
 | Write / fix shader `SHADER_SRC`, uniforms, sampling, fog, transparency | **Yes** | — |
 | Compile, seed registers, `ttsl_run` smoke tests | **Yes** | — |
-| Textual demos using `ShaderPy` | **Yes** (shader body); wiring checklist in [demos-standards](../../../.cursor/rules/demos-standards.mdc) | [tt3de-demomaker](../tt3de-demomaker/SKILL.md) for discovery |
+| Textual demos using `ShaderPy` | **Yes** — all `SHADER_SRC` bodies | [tt3de-demomaker](../tt3de-demomaker/SKILL.md) wires the demo only; it **delegates** shader source here |
 | New TTSL builtin needing texture buffer / raster / material bridge in Rust | Opcode + compiler here | [tt3de-low](../tt3de-low/SKILL.md) for engine hook |
 | Scene graph, prefabs, loaders (no TTSL) | — | [tt3de-high](../tt3de-high/SKILL.md) |
 

--- a/.opencode/skills/ttsl-implementation/SKILL.md
+++ b/.opencode/skills/ttsl-implementation/SKILL.md
@@ -1,120 +1,186 @@
 ---
 name: ttsl-implementation
-description: Implements or changes Tiny Tiny Shader Language (TTSL) shaders, compiler, VM opcodes, or TTSL-related docs in tt3de. Use when writing TTSL source, editing python/tt3de/ttsl/, Rust TTSL VM/material paths, or when the user mentions TTSL, shader materials, bytecode, builtins (tt_FragCoord, tt_Time), all_passes_compilation, ttsl_run, ShaderPy, gen-opcodes, low_level_def, or opcode definitions.
+description: >-
+  Writes and edits Tiny Tiny Shader Language (TTSL) shader source, and implements
+  compiler / VM / opcode changes when needed. Use for TTSL materials, shading logic,
+  all_passes_compilation, ttsl_run, ShaderPy, globals_dict, tt_* builtins,
+  tt_texture, or extending python/tt3de/ttsl/, low_level_def, gen-opcodes.
+disable-model-invocation: true
 ---
 
-# TTSL implementation
+# TTSL coder
 
-## Documentation map
+You are the **TTSL language specialist** in tt3de. Default to **authoring correct shader source** that compiles and matches engine semantics. Touch the compiler, ISA, or Rust VM only when the task is explicitly to add or change language / opcode behavior.
 
-Read these before changing behavior; they are the contract:
+## Documentation map (read first)
+
+These files are the contract; prefer them over memory or GLSL habits:
 
 | Topic | File |
 |-------|------|
-| Builtins, uniforms, texture ABI, material bridge | [source/ttsl.md](../../source/ttsl.md) |
-| Compiler API, `globals_dict`, supported syntax | [source/ttsl_compiler.md](../../source/ttsl_compiler.md) |
-| Opcode numbers and operand types (generated) | [source/opcode_reference.md](../../source/opcode_reference.md) |
+| Builtins, uniforms, textures, transparency, material bridge | [source/ttsl.md](../../../source/ttsl.md) |
+| `globals_dict`, compile API, pipeline overview | [source/ttsl_compiler.md](../../../source/ttsl_compiler.md) |
+| Opcode numbers and operand types (generated) | [source/opcode_reference.md](../../../source/opcode_reference.md) |
 
-## Authoring shader source
+**Shipped vs Planned:** the primitives table in `source/ttsl.md` lists intent. Before using a function name, confirm it compiles (grep `tests/tt3de/ttsl/` or run `all_passes_compilation` on a minimal snippet). **Planned** or **Missing** rows are not safe to use in production shaders unless you are implementing them in the same change.
 
-- **Return type**: `(front, back, glyph)` as `(vec4, vec4, int)`, matching VM `OP_RET`. Annotate `tuple[vec4, vec4, int]` (or `typing.Tuple[...]`) when typing the entry function.
-- **Per-cell builtins** (`tt_FragCoord`, `tt_FragPos`, `tt_Normal`, `tt_ViewPos`, `tt_TexCoord0`, `tt_TexCoord1`, `tt_FrontFacing`, `tt_FragDepth`, `tt_LineCoord`, `tt_PointCoord`, `tt_PrimitiveID`): known to the compiler; see `ttsl_compiler.md` for parameter declarations vs implicit slots.
-- **Engine uniforms** (`tt_Time`, `tt_DeltaTime`, `tt_Frame`, `tt_Resolution`, `tt_Near`, `tt_Far`): include in `globals_dict` with the types documented in `ttsl.md` / `ttsl_compiler.md`; wire runtime setters and `ShaderPy.*_reg` to match `RegisterSettings` after `all_passes_compilation`.
-- **Naming**: `tt_` + CamelCase, analogous to GLSL `gl_`.
-- **Sampling**: only `tt_texture(index: int, coord: vec2) -> vec4` (and `tt_texelFetch` when implemented end-to-end—confirm opcode + compiler + tests). Use `tt_TexCoord*` for interpolated coords. Standalone Python `ttsl_run` does not bind textures; expect black or engine-defined fallback unless exercising through `Shader` + `TextureBuffer`.
-- **Python next to shaders**: `from pyglm import glm` (same prelude convention as AGENTS.md).
+## Scope and boundaries
 
-## Compiler and bytecode
+| Task | This skill | Hand off |
+|------|------------|----------|
+| Write / fix shader `SHADER_SRC`, uniforms, sampling, fog, transparency | **Yes** | — |
+| Compile, seed registers, `ttsl_run` smoke tests | **Yes** | — |
+| Textual demos using `ShaderPy` | **Yes** (shader body); wiring checklist in [demos-standards](../../../.cursor/rules/demos-standards.mdc) | [tt3de-demomaker](../tt3de-demomaker/SKILL.md) for discovery |
+| New TTSL builtin needing texture buffer / raster / material bridge in Rust | Opcode + compiler here | [tt3de-low](../tt3de-low/SKILL.md) for engine hook |
+| Scene graph, prefabs, loaders (no TTSL) | — | [tt3de-high](../tt3de-high/SKILL.md) |
 
-- **Pipeline entry**: `all_passes_compilation(src, func_name, globals_dict)` in `python/tt3de/ttsl/compiler.py`.
-- **ISA / opcode definition changes**: edit `python/tt3de/ttsl/ttisa/low_level_def.py`, then run `make gen-opcodes` or `bash scripts/gen_opcodes.sh` (PowerShell script on Windows). That refreshes Rust opcodes, Python opcode tables, and `source/opcode_reference.md`.
-- **Lowering gaps**: consult `source/ttsl_compiler.md` (supported features, typability in `type_of`, notes like partially wired helpers). Do not assume a name in `ttsl.md` primitives table compiles until verified in the compiler and tests.
+## What TTSL is
 
-## Key architecture: what is generated vs manual
+TTSL is a **typed, Python-syntax shader subset** compiled to tt3de VM bytecode. It is **not** full Python: no imports inside shader source, no `for` loops, no classes, no lambdas, no list/dict literals as language features. The compiler strips bare `print` and import statements from the parsed function body.
 
-**`src/ttsl/opcodes.rs` is fully auto-generated** by `low_level_def.py` via `gen-opcodes`. Never hand-edit it. The generator builds the entire Rust `exec_opcode` match block from Python `Form` definitions, including `unsafe` register access. For standard math operations the Rust VM implementation requires zero manual Rust coding.
+- **Types:** `float`, `int`, `bool`, `vec2`, `vec3`, `vec4` (construct with `vec2(...)` / `glm.vec2(...)`).
+- **GLM:** host Python uses `from pyglm import glm`; in shaders prefer **`glm.sin`**, **`glm.vec4`**, etc. when that matches existing demos—many bare names (`sin`, `clamp`, `mod`) also work when listed below.
+- **Naming:** engine builtins use `tt_` + CamelCase (GLSL `gl_` analogue), e.g. `tt_FragCoord`, `tt_Time`.
 
-**`PassToByteCode.find_form` is generic.** It matches IR instructions to bytecode forms by checking `instr.op.name in form["name"]` (substring) and comparing type tuples. New opcodes that follow existing patterns (unary same-type, binary same-type) need **no back-end changes** — the generic matcher handles them automatically.
+## Shader entry contract
 
-**Opcode index assignment is sequential** across all `CategoryGroup`s in `generate_all_forms()`. Adding forms anywhere shifts downstream indices. Always regenerate after ISA edits; never hand-edit `ttisa_opcodes.py` or `opcodes.rs`.
+Every entry function must **`return (front, back, glyph)`** with types **`(vec4, vec4, int)`** (VM `OP_RET`).
 
-## Adding a new builtin (end-to-end)
+- **`front` / `back`:** RGBA for the terminal cell’s foreground and background halves. Shader materials write these **directly**—there is no post-pass alpha compositing. See **Transparency** below.
+- **`glyph`:** glyph index (`int`); `0` is common when color alone drives the look.
 
-Determine the **shape** of the new builtin first — this determines which pattern to follow:
+Annotate the return type: `-> tuple[vec4, vec4, int]`. List builtins as parameters when you want explicit slots (e.g. `tt_TexCoord0: vec2`); omitting them still works for implicit per-cell inputs.
 
-### Pattern A: Unary math (like `sin`, `abs`, `floor`, `ceil`, `fract`)
+### Builtins and `globals_dict`
 
-Signature: `func(x) -> T` where input and output share the same type (F32, V2, V3, V4).
+| Category | Names | `globals_dict` |
+|----------|-------|----------------|
+| **Per-cell inputs** | `tt_FragCoord`, `tt_FragPos`, `tt_Normal`, `tt_ViewPos`, `tt_TexCoord0`, `tt_TexCoord1`, `tt_FrontFacing`, `tt_FragDepth`, `tt_LineCoord`, `tt_PointCoord`, `tt_PrimitiveID` | **Do not** list—compiler + material bridge fill each pixel |
+| **Engine uniforms** | `tt_Time`, `tt_DeltaTime`, `tt_Frame`, `tt_Resolution`, `tt_Near`, `tt_Far` | **Include** each name the shader reads, mapped to `float`, `int`, or `glm.vec2` **type objects** (not runtime values) |
+| **User uniforms** | e.g. `u_color`, `u_TextureIndex` | Same: name → type; after compile use `RegisterSettings.set_variable` and `register_seed=reg_settings.get_register_list()` on `ShaderPy` |
 
-**Files to edit (in order):**
+`globals_dict` values are **types only**. Runtime values go through `set_variable`, `ShaderPy.*_reg`, and `MaterialBufferPy.set_shader_*` for engine uniforms. Details and examples: `source/ttsl_compiler.md`.
 
-1. **`python/tt3de/ttsl/ttsl_assembly.py`** — Add `MYOP = "myop"` to the `OpCodes` enum.
+Use `GLOBAL_VAR_TT_TIME` from `tt3de.ttsl.compiler` in host Python when wiring `tt_Time` (matches demos).
 
-2. **`python/tt3de/ttsl/ttisa/low_level_def.py`** — Three changes:
-   - Add `OpCodes.MYOP` to both `MATH_FUNCTION_NATIVE_TYPES` (F32 method syntax: `"{a}.myop()"`) and `MATH_FUNCTION_VEC_TYPES` (nalgebra_glm free function: `"myop(&{a})"`).
-   - Add `OpCodes.MYOP` to the unary ops list inside the `"Unary Math"` `CategoryGroup` in `generate_all_forms()`.
-   - Add the nalgebra_glm symbol to the `use nalgebra_glm::{...}` line in `RUST_OPCODE_FILE_PRELUDE` inside `main()`.
+### Textures
 
-3. **`python/tt3de/ttsl/compiler.py`** — Five touch points:
-   - `NATIVE_UNI_OPS_TYPE` dict — add `"myop": (IRType.F32, IRType.V2, IRType.V3, IRType.V4)`.
-   - `compile_expr` bare-call list — add `"myop"` to the `func.id in ("sin", "abs", "cos", "floor", "ceil", "fract", "normalize")` tuple. The `glm.myop(...)` path is handled automatically by the existing `NATIVE_UNI_OPS_TYPE` check.
-   - `type_of` for `ast.Name` — add `"myop"` to the `node.id in ("abs", "sin", "cos", "floor", "ceil", "fract", "normalize")` tuple.
-   - `type_of` for `ast.Attribute` — add `"myop"` to the `node.attr in ("sin", "cos", "floor", "ceil", "fract", "normalize")` tuple.
-   - `opcode_for_uniop` — add `"myop": OpCodes.MYOP` to the `name_to_op` dict (currently maps `sin`, `abs`, `floor`, `ceil`, `fract`, `normalize`).
+- **`tt_texture(texture_index: int, coord: vec2) -> vec4`** — filtered sample; pair with **`tt_TexCoord0`** / **`tt_TexCoord1`** or other `vec2` UVs.
+- Declare texture index in `globals_dict` as `int` (e.g. `"u_TextureIndex": int`) and `set_variable` before `ttsl_run` or engine draw.
+- **`tt_texelFetch`:** specified in `source/ttsl.md` but **not** end-to-end in the compiler yet—do not use until shipped.
+- Standalone **`ttsl_run`** has **no** texture binding (typically black). Full sampling needs **`ShaderPy`** + **`TextureBuffer`** in a demo or test harness.
 
-4. **Regenerate and rebuild** — `bash scripts/gen_opcodes.sh && cargo check --all-targets && uv run maturin develop`.
+### Transparency (critical)
 
-5. **Tests** — Add e2e tests in `tests/tt3de/ttsl/test_e2e.py` using `all_passes_compilation` + `ttsl_run`. Cover: constant input, negative/edge cases, runtime variable input, and `glm.myop(...)` spelling. The `all_passes_compilation` + `ttsl_run` pattern exercises the full pipeline (front end → IR → SSA → bytecode → VM) in one test.
+When texels can be transparent, **mask in the shader**—return black (or your clear color) for both `front` and `back` where alpha is low. For **two UV sets** (`tt_TexCoord0` and `tt_TexCoord1`), mask **each half independently** to avoid key-color fringes. Copy patterns from `source/ttsl.md` (single-path and double-raster examples).
 
-6. **Documentation** — Update the primitives table in `source/ttsl.md`: change row from **Planned** to **Shipped** with notes on supported spellings.
+## Language surface (authoring)
 
-### Pattern B: Binary same-type math (like `mod`)
+Use this when writing shaders today. If something fails with `CompileError` or `NotImplementedError`, check **Pitfalls** before “fixing” the compiler.
 
-Signature: `func(x, y) -> T` where both inputs and output share the same type.
+**Statements:** annotated assignment (`x: float = ...`), plain assignment, `if` / `else`, `while`, `return` (triple only).
 
-If the operation maps to a simple Rust operator (`+`, `-`, `*`, `/`), add it to `generate_binary_unitype_forms`. Otherwise, write a **custom form generator** (see `generate_mod_forms()` for the pattern — it builds `Form` dicts with hand-written `rust_match_code` per type).
+**Operators:** `+ - * /` on scalars and vectors; comparisons `> >= < <=`; boolean `and` / `or` (operands must be `bool`—use comparisons, not `if x:` on floats).
 
-**Files to edit:**
+**Calls — prefer these (bare and/or `glm.*` where noted):**
 
-1. **`python/tt3de/ttsl/ttsl_assembly.py`** — Add `MYOP = "myop"` to `OpCodes`.
+| Category | Names |
+|----------|--------|
+| Unary math | `sin`, `abs`, `floor`, `ceil`, `fract`, `normalize` |
+| Binary / n-ary | `mod`, `dot`, `length`, `max`, `clamp` (3 args) |
+| GLM tools | **`glm.mix(a, b, t)`** — `vec2/3/4` × same × `float` `t`; bare `mix(...)` is **not** wired |
+| Texture | `tt_texture` |
+| Constructors | `vec2`, `vec3`, `vec4`, `glm.vec2`, `glm.vec3`, `glm.vec4` |
+| Swizzles | `.x`, `.y`, `.z`, `.w` on vectors |
 
-2. **`python/tt3de/ttsl/ttisa/low_level_def.py`** — Write a generator function (or extend an existing one) that produces `Form` dicts for each type variant. Add a `CategoryGroup` to `generate_all_forms()`. For vector variants that need component-wise expansion (no nalgebra_glm free function), generate explicit `VecN::new(a.x op b.x, a.y op b.y, ...)` Rust code. Update `RUST_OPCODE_FILE_PRELUDE` imports if needed.
+**Not supported (do not use in shaders):** `for`, `try`, classes, nested `def`, arbitrary Python calls, `min` (not shipped), `sign`, `pow`, `smoothstep`, most of the **Planned** table in `source/ttsl.md`.
 
-3. **`python/tt3de/ttsl/compiler.py`** — Handle both bare `myop(x, y)` and `glm.myop(x, y)`:
-   - `compile_expr` bare call: add an `elif func.id == "myop"` block that validates 2 args, checks same type, compiles both, and calls `self.emit_2(OpCodes.MYOP, ...)`.
-   - `compile_expr` glm attribute: add `elif func_name == "myop"` in the `glm` branch with the same logic.
-   - `type_of` for `ast.Name`: add `elif node.id == "myop"` returning `type_args[0]` after validating 2 same-type args.
-   - `type_of` for `ast.Attribute`: add `elif node.attr == "myop"` with same validation.
+### Pitfalls (common author mistakes)
 
-4. **Regenerate, rebuild, test, document** — same as Pattern A steps 4–6.
+| Looks valid | Actually |
+|-------------|----------|
+| `cos`, `tan` (bare or `glm.cos`) | Often **type-check** but **`opcode_for_uniop` has no `cos`** — use **`sin`** / phase tricks or implement cos in the same change |
+| `min` | **Not shipped** — use `max` on negated values or compare via `if` |
+| `mix(a,b,t)` without `glm.` | **Not wired** — use **`glm.mix`** |
+| `tt_texelFetch` | **Not end-to-end** |
+| Name in `ttsl.md` **Planned** | Verify compile + test before relying on it |
+| `globals_dict` with `tt_FragCoord` | Wrong layer—per-cell builtins are implicit |
+| Expect alpha compositing after return | **Must** zero/mask colors in shader |
+| `ttsl_run` for textured effects | No texture buffer—use engine path or tests that bind textures |
 
-### Pattern C: Special / cross-type operations (like `tt_texture`, `mix`)
+## Workflow: write or change a shader
 
-Operations with mixed input types, engine hooks (texture buffer, etc.), or non-register data need custom handling. See `generate_tt_texture_form()` and `generate_glm_tool_mix_forms()` for examples. **Before coding, confirm with the user** the intended strategy when execution needs data beyond VM registers.
+1. **Read** the relevant sections of `source/ttsl.md` (builtins + primitives + transparency).
+2. **Draft** the entry function: typed locals, explicit `return (front, back, glyph)`.
+3. **Compile** from host Python:
 
-## Rust expression patterns in `low_level_def.py`
+```python
+from pyglm import glm
+from tt3de.ttsl.compiler import GLOBAL_VAR_TT_TIME, all_passes_compilation
 
-| Type | Unary template style | Binary template style |
-|------|---------------------|----------------------|
-| F32 | `"{a}.sin()"` (method on `f32`) | `"{a} + {b}"` (Rust operator) |
-| V2/V3/V4 | `"sin(&{a})"` (nalgebra_glm free fn) | `"{a} + {b}"` (nalgebra operator overload) |
+bytecode, reg_settings = all_passes_compilation(
+    SHADER_SRC,
+    "entry_fn_name",
+    globals_dict={GLOBAL_VAR_TT_TIME: float, "u_MyUniform": glm.vec3},  # only names you read
+)
+```
 
-For operations without a nalgebra_glm free function on vectors, use component-wise expansion: `VecN::new(a_val.x.op(), a_val.y.op(), ...)` — see `_mod_rust_body_vec` for the pattern.
+4. **Smoke-test** when logic is non-trivial:
 
-## Back end: why no changes are usually needed
+```python
+from tt3de.tt3de import ttsl_run
+from tt3de.ttsl.compiler import PIXELVAR_TT_TEXCOORD0
 
-`PassToByteCode.find_form` matches IR instructions to bytecode forms generically:
-- It iterates all forms from `generate_all_forms()`.
-- For non-control-flow ops, it checks `instr.op.name in form["name"]` (e.g. `"FLOOR"` is in `"FLOOR_F32"`).
-- It then compares the full type tuple `(dst_ty, src1_ty, ...)` against `(form output_type, form input_types)`.
-- `transform_instr_to_bytecode` encodes each instruction as `[opcode_index, dst_reg, a_reg, b_reg, c_reg, d_reg]`.
+reg_settings.set_variable(GLOBAL_VAR_TT_TIME, 1.0)
+reg_settings.set_variable(PIXELVAR_TT_TEXCOORD0, glm.vec2(0.5, 0.5))
+front, back, glyph = ttsl_run(*reg_settings.get_register_list(), bytecode)
+```
 
-New opcodes that follow the unary (`emit_1`) or binary (`emit_2`) pattern are matched automatically. You only need to touch `PassToByteCode` for operations with unusual operand layouts (e.g. `TT_TEXTURE` uses `emit(...)` with explicit 4 sources, `MIX` uses 3 sources across different type banks).
+5. **Integrate** into a demo/app: `materials.ShaderPy(..., register_seed=reg_settings.get_register_list())`, material slot 0 static sentinel, `set_shader_time` in `before_render_step`—see [demos-standards](../../../.cursor/rules/demos-standards.mdc) and `demos/2d/ttsl_square.py`.
 
-## Tests and doc updates
+6. **Mirror** non-obvious behavior in `tests/tt3de/ttsl/test_e2e.py` when fixing a regression.
 
-- **E2E tests** in `tests/tt3de/ttsl/test_e2e.py` are the primary validation: compile + `ttsl_run` exercises the entire pipeline. Cover constant inputs, edge cases (negatives, zero), runtime variable inputs, and both bare and `glm.` spellings.
-- **Compiler-only tests** in `tests/tt3de/ttsl/test_compiler.py` for error cases (wrong arg count, type mismatches).
-- Rust-side tests in `src/ttsl/mod.rs` (`#[cfg(test)]`) are only needed for ops that interact with engine surfaces (textures, etc.); pure math ops are fully exercised by the Python e2e path.
-- Run `PYTHONPATH=. uv run pytest tests/tt3de/ -v` to validate (skip `tests/benchs/` which are slow).
-- Update `source/ttsl.md` primitives table in the same change: **Planned** → **Shipped** with notes.
+Do **not** jump to `low_level_def.py` or opcode work when the user only asked for a shader effect solvable with the shipped surface.
+
+## Compiler and bytecode (when extending the language)
+
+**Pipeline entry:** `all_passes_compilation(src, func_name, globals_dict)` in `python/tt3de/ttsl/compiler.py`.
+
+**ISA changes:** edit `python/tt3de/ttsl/ttisa/low_level_def.py`, then `make gen-opcodes` or `bash scripts/gen_opcodes.sh` (PowerShell on Windows). Regenerates Rust opcodes, Python tables, and `source/opcode_reference.md`.
+
+### Generated vs manual
+
+- **`src/ttsl/opcodes.rs` is fully auto-generated** — never hand-edit.
+- **`PassToByteCode.find_form`** matches unary/binary same-type ops generically; unusual layouts (`TT_TEXTURE`, `MIX`, `CLAMP`) need explicit `emit` paths in `compiler.py`.
+- Opcode indices are **sequential** across `generate_all_forms()` — always regenerate after ISA edits; never hand-edit `ttisa_opcodes.py`.
+
+### Adding a new operation (summary)
+
+Pick a pattern by shape; full file-level steps apply when implementing:
+
+| Pattern | Examples | Main touch points |
+|---------|----------|-------------------|
+| **A — Unary same-type** | `sin`, `floor`, `abs` | `ttsl_assembly.py`, `low_level_def.py`, `compiler.py` (`NATIVE_UNI_OPS_TYPE`, bare/`glm` lists, `opcode_for_uniop`), gen-opcodes |
+| **B — Binary same-type** | `mod`, `max` | Same + custom `Form` generator if not a Rust operator |
+| **C — Special** | `tt_texture`, `glm.mix` | Custom `Form` + `compile_expr` / `compile_glm_tool_call`; confirm Rust bridge with user if data leaves VM registers |
+
+After implementation: `bash scripts/gen_opcodes.sh && cargo check --all-targets && uv run maturin develop`, e2e tests in `tests/tt3de/ttsl/test_e2e.py`, compiler errors in `test_compiler.py`, update **`source/ttsl.md`** row **Planned → Shipped**.
+
+**Rust VM tests** (`src/ttsl/mod.rs`) only for engine-coupled ops; pure math is covered by Python e2e.
+
+Run: `PYTHONPATH=. uv run pytest tests/tt3de/ttsl/ -v` (skip `tests/benchs/` unless needed).
+
+## Verification checklist
+
+**Shader-only change**
+
+- [ ] Uses only shipped calls (see **Language surface** / **Pitfalls**)
+- [ ] Correct `globals_dict` (types only; per-cell builtins omitted)
+- [ ] Returns `(vec4, vec4, int)`; transparency handled in-shader if needed
+- [ ] `all_passes_compilation` succeeds; `ttsl_run` or demo path exercised when non-trivial
+
+**Compiler / opcode change**
+
+- [ ] `gen-opcodes` run; no hand-edited `opcodes.rs` / `ttisa_opcodes.py`
+- [ ] `cargo check --all-targets` clean; `uv run pytest tests/tt3de/ttsl/`
+- [ ] `source/ttsl.md` (+ opcode reference via generator) updated


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Aligns Cursor agent skills so **TTSL shader authoring** and **demo scaffolding** have clear owners.

### TTSL coder (`ttsl-implementation`)
- Defaults to writing correct `SHADER_SRC` per `source/ttsl.md` / `source/ttsl_compiler.md`.
- Documents language surface, pitfalls, and shader workflow.
- Compiler/opcode work stays in a secondary section.

### Demomaker (`tt3de-demomaker`)
- **Does not** write or patch `SHADER_SRC`.
- Owns Textual app, scene graph, `ShaderPy` wiring, textures, discovery.
- **Delegates** shader bodies and compile fixes to `ttsl-implementation`, with a user-facing prompt template when blocked.

### Also
- `demos-standards.mdc` notes `SHADER_SRC` is owned by the TTSL skill.
- Mirrored updates under `.opencode/skills/`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5e355ed9-669f-4471-a2e9-e3e5caea30a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5e355ed9-669f-4471-a2e9-e3e5caea30a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

